### PR TITLE
Add gruvbox theme and throughput graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `toptop` is a terminal-based system monitor inspired by btop. It displays CPU, memory, disk, and network usage with a lightweight curses interface.
 
-The enhanced version shows per-core CPU usage, current CPU frequency, memory consumption, disk read/write speeds, network transfer rates, and system uptime.
+The latest version adds a colourful gruvbox theme. CPU usage is shown with per-core bars, while disk and network throughput are plotted using small graphs so you can see trends over time. It still shows CPU frequency, memory consumption, and system uptime.
 
 ## Installation
 

--- a/toptop/main.py
+++ b/toptop/main.py
@@ -4,6 +4,39 @@ import psutil
 import curses
 from dataclasses import dataclass
 
+BLOCKS = " ▁▂▃▄▅▆▇█"
+
+def usage_bar(pct: float, width: int = 20) -> str:
+    filled = int(pct / 100 * width)
+    return "█" * filled + " " * (width - filled)
+
+def sparkline(history: list[float], max_value: float, width: int) -> str:
+    if max_value <= 0:
+        max_value = 1
+    result = []
+    for val in history[-width:]:
+        level = int(val / max_value * (len(BLOCKS) - 1))
+        result.append(BLOCKS[level])
+    if len(result) < width:
+        result = [" "] * (width - len(result)) + result
+    return "".join(result)
+
+def setup_colors():
+    curses.start_color()
+    curses.use_default_colors()
+    if curses.COLORS >= 256:
+        curses.init_pair(1, 208, -1)  # orange
+        curses.init_pair(2, 142, -1)  # green
+        curses.init_pair(3, 109, -1)  # blue
+        curses.init_pair(4, 175, -1)  # purple
+        curses.init_pair(5, 223, -1)  # light text
+    else:
+        curses.init_pair(1, curses.COLOR_YELLOW, -1)
+        curses.init_pair(2, curses.COLOR_GREEN, -1)
+        curses.init_pair(3, curses.COLOR_BLUE, -1)
+        curses.init_pair(4, curses.COLOR_MAGENTA, -1)
+        curses.init_pair(5, curses.COLOR_WHITE, -1)
+
 @dataclass
 class SystemStats:
     cpu_percents: list[float]
@@ -33,13 +66,16 @@ def gather_stats() -> SystemStats:
 async def refresh_screen(stdscr):
     curses.curs_set(0)
     stdscr.nodelay(True)
-    curses.start_color()
-    curses.use_default_colors()
-    curses.init_pair(1, curses.COLOR_CYAN, -1)
+    setup_colors()
 
     prev_disk = psutil.disk_io_counters()
     prev_net = psutil.net_io_counters()
     prev_time = time.time()
+    net_up_hist: list[float] = []
+    net_down_hist: list[float] = []
+    disk_read_hist: list[float] = []
+    disk_write_hist: list[float] = []
+    graph_width = 30
 
     while True:
         now_disk = psutil.disk_io_counters()
@@ -54,18 +90,38 @@ async def refresh_screen(stdscr):
 
         stats = gather_stats()
 
+        disk_read_hist.append(disk_read)
+        disk_write_hist.append(disk_write)
+        net_up_hist.append(net_sent)
+        net_down_hist.append(net_recv)
+        for hist in (disk_read_hist, disk_write_hist, net_up_hist, net_down_hist):
+            if len(hist) > graph_width:
+                hist.pop(0)
+
+        disk_max = max(max(disk_read_hist, default=0), max(disk_write_hist, default=0))
+        net_max = max(max(net_up_hist, default=0), max(net_down_hist, default=0))
+
         stdscr.erase()
-        stdscr.addstr(0, 0, "toptop - enhanced monitor", curses.color_pair(1))
-        stdscr.addstr(2, 0, f"Uptime: {stats.uptime}")
-        stdscr.addstr(4, 0, f"CPU Frequency: {stats.cpu_freq:.0f} MHz")
+        stdscr.addstr(0, 0, "toptop - gruvbox monitor", curses.color_pair(1) | curses.A_BOLD)
+        stdscr.addstr(2, 0, f"Uptime: {stats.uptime}", curses.color_pair(5))
+        stdscr.addstr(4, 0, f"CPU Frequency: {stats.cpu_freq:.0f} MHz", curses.color_pair(5))
+        line = 5
         for idx, pct in enumerate(stats.cpu_percents):
-            stdscr.addstr(5 + idx, 0, f"CPU{idx}: {pct:5.1f}%")
-        mem_line = 6 + len(stats.cpu_percents)
-        stdscr.addstr(mem_line, 0, f"Memory: {stats.mem_used/1e6:.0f}M / {stats.mem_total/1e6:.0f}M")
-        stdscr.addstr(mem_line + 1, 0, f"Disk Usage: {stats.disk_percent:.1f}%")
-        stdscr.addstr(mem_line + 2, 0, f"Disk R/W: {disk_read/1e6:.1f}M/s {disk_write/1e6:.1f}M/s")
-        stdscr.addstr(mem_line + 3, 0, f"Net Up/Down: {net_sent/1e6:.1f}M/s {net_recv/1e6:.1f}M/s")
-        stdscr.addstr(mem_line + 5, 0, "Press 'q' to quit")
+            bar = usage_bar(pct)
+            stdscr.addstr(line, 0, f"CPU{idx}: ", curses.color_pair(5))
+            stdscr.addstr(bar, curses.color_pair(2))
+            stdscr.addstr(f" {pct:5.1f}%", curses.color_pair(5))
+            line += 1
+        mem_line = line
+        stdscr.addstr(mem_line, 0, f"Memory: {stats.mem_used/1e6:.0f}M / {stats.mem_total/1e6:.0f}M", curses.color_pair(5))
+        stdscr.addstr(mem_line + 1, 0, f"Disk Usage: {stats.disk_percent:.1f}%", curses.color_pair(5))
+        stdscr.addstr(mem_line + 2, 0, f"Disk R/s: {disk_read/1e6:.1f}M/s  Disk W/s: {disk_write/1e6:.1f}M/s", curses.color_pair(4))
+        stdscr.addstr(mem_line + 3, 0, sparkline(disk_read_hist, disk_max, graph_width), curses.color_pair(4))
+        stdscr.addstr(mem_line + 4, 0, sparkline(disk_write_hist, disk_max, graph_width), curses.color_pair(4))
+        stdscr.addstr(mem_line + 6, 0, f"Net Up: {net_sent/1e6:.1f}M/s  Net Down: {net_recv/1e6:.1f}M/s", curses.color_pair(3))
+        stdscr.addstr(mem_line + 7, 0, sparkline(net_up_hist, net_max, graph_width), curses.color_pair(3))
+        stdscr.addstr(mem_line + 8, 0, sparkline(net_down_hist, net_max, graph_width), curses.color_pair(3))
+        stdscr.addstr(mem_line + 10, 0, "Press 'q' to quit", curses.color_pair(5))
 
         stdscr.refresh()
         try:


### PR DESCRIPTION
## Summary
- show CPU, memory, disk and network with a gruvbox colour scheme
- add CPU usage bars
- plot disk and network throughput history as unicode graphs
- update README with new features

## Testing
- `python -m py_compile toptop/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684188c78680832e99c73ec46e9c1146