### PR TITLE
Derive signal name/number from one authoritative SIGNALS table

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use sysinfo::Signal;
 
 use crate::alerts::{self, Alert, AlertConfig};
 use crate::config::Config;
-use crate::metrics::{Collector, Connection, ProcInfo, SignalOutcome};
+use crate::metrics::{signal_name, Collector, Connection, ProcInfo, SignalOutcome, SIGNALS};
 use crate::theme::{Theme, THEMES};
 
 /// Process table sort columns.
@@ -100,20 +100,6 @@ pub struct PendingKill {
     pub name: String,
     pub signal: Signal,
 }
-
-/// Signals offered by the interactive signal menu (label, number, signal).
-/// Numbers come straight from libc so they are correct on every platform.
-pub const SIGNALS: &[(&str, i32, Signal)] = &[
-    ("SIGTERM", libc::SIGTERM, Signal::Term),
-    ("SIGKILL", libc::SIGKILL, Signal::Kill),
-    ("SIGINT", libc::SIGINT, Signal::Interrupt),
-    ("SIGHUP", libc::SIGHUP, Signal::Hangup),
-    ("SIGQUIT", libc::SIGQUIT, Signal::Quit),
-    ("SIGSTOP", libc::SIGSTOP, Signal::Stop),
-    ("SIGCONT", libc::SIGCONT, Signal::Continue),
-    ("SIGUSR1", libc::SIGUSR1, Signal::User1),
-    ("SIGUSR2", libc::SIGUSR2, Signal::User2),
-];
 
 /// The whole runtime state.
 pub struct App {
@@ -707,22 +693,5 @@ pub fn header_sort_at(rel_x: u16) -> Option<SortField> {
         47..=54 => Some(SortField::Time),
         55..=56 => None,
         _ => Some(SortField::Name),
-    }
-}
-
-/// Human label for a signal. Covers every signal reachable from the menu; the
-/// single source of truth shared by the confirm prompt and the status line.
-pub fn signal_name(sig: Signal) -> &'static str {
-    match sig {
-        Signal::Term => "SIGTERM",
-        Signal::Kill => "SIGKILL",
-        Signal::Interrupt => "SIGINT",
-        Signal::Hangup => "SIGHUP",
-        Signal::Quit => "SIGQUIT",
-        Signal::Stop => "SIGSTOP",
-        Signal::Continue => "SIGCONT",
-        Signal::User1 => "SIGUSR1",
-        Signal::User2 => "SIGUSR2",
-        _ => "signal",
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -4,7 +4,7 @@
 //! histories. Calling [`Collector::refresh`] once per tick updates every public
 //! field in place — the UI layer only ever reads from a `&Collector`.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use sysinfo::{
     Components, CpuRefreshKind, Disks, MemoryRefreshKind, Networks, Pid, ProcessRefreshKind,
@@ -280,11 +280,12 @@ impl Collector {
         self.gpus = gpu_snap.gpus;
         self.gpu_procs = gpu_snap.procs;
         self.servers = self.infer_monitor.snapshot();
-        // Battery level moves on the order of minutes; poll it at most every
-        // 10s rather than doing filesystem I/O on every (up to 4×/s) tick.
+        // Battery level moves on the order of minutes; poll it at most this
+        // often rather than doing filesystem I/O on every (up to 4×/s) tick.
+        const BATTERY_POLL: Duration = Duration::from_secs(10);
         if self
             .last_battery_at
-            .map(|t| now.duration_since(t).as_secs() >= 10)
+            .map(|t| now.duration_since(t) >= BATTERY_POLL)
             .unwrap_or(true)
         {
             self.battery = read_battery();
@@ -544,21 +545,37 @@ impl Collector {
     }
 }
 
-/// Map a sysinfo `Signal` to its platform signal number, or `None` if it is
-/// not one we support delivering.
+/// The signals offered by the interactive menu, in display order: label,
+/// platform signal number (straight from libc), and the sysinfo `Signal`.
+/// Single source of truth — the menu, status line, and delivery all derive
+/// from this, so a new signal is added in exactly one place.
+pub const SIGNALS: &[(&str, i32, Signal)] = &[
+    ("SIGTERM", libc::SIGTERM, Signal::Term),
+    ("SIGKILL", libc::SIGKILL, Signal::Kill),
+    ("SIGINT", libc::SIGINT, Signal::Interrupt),
+    ("SIGHUP", libc::SIGHUP, Signal::Hangup),
+    ("SIGQUIT", libc::SIGQUIT, Signal::Quit),
+    ("SIGSTOP", libc::SIGSTOP, Signal::Stop),
+    ("SIGCONT", libc::SIGCONT, Signal::Continue),
+    ("SIGUSR1", libc::SIGUSR1, Signal::User1),
+    ("SIGUSR2", libc::SIGUSR2, Signal::User2),
+];
+
+/// Human label for a signal, or "signal" if it isn't one the menu offers.
+pub fn signal_name(sig: Signal) -> &'static str {
+    SIGNALS
+        .iter()
+        .find(|(_, _, s)| *s == sig)
+        .map(|(name, _, _)| *name)
+        .unwrap_or("signal")
+}
+
+/// Platform signal number for a signal, or `None` if we don't deliver it.
 fn raw_signal(sig: Signal) -> Option<i32> {
-    Some(match sig {
-        Signal::Term => libc::SIGTERM,
-        Signal::Kill => libc::SIGKILL,
-        Signal::Interrupt => libc::SIGINT,
-        Signal::Hangup => libc::SIGHUP,
-        Signal::Quit => libc::SIGQUIT,
-        Signal::Stop => libc::SIGSTOP,
-        Signal::Continue => libc::SIGCONT,
-        Signal::User1 => libc::SIGUSR1,
-        Signal::User2 => libc::SIGUSR2,
-        _ => return None,
-    })
+    SIGNALS
+        .iter()
+        .find(|(_, _, s)| *s == sig)
+        .map(|(_, num, _)| *num)
 }
 
 /// Outcome of attempting to deliver a signal to a process.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -961,14 +961,14 @@ fn render_signal_menu(f: &mut Frame, area: Rect, theme: &Theme, idx: usize, app:
         .selected_proc()
         .map(|p| format!("{} ({})", truncate(&p.name, 20), p.pid))
         .unwrap_or_else(|| "process".into());
-    let rect = centered(area, 40, (crate::app::SIGNALS.len() + 3) as u16);
+    let rect = centered(area, 40, (crate::metrics::SIGNALS.len() + 3) as u16);
     f.render_widget(Clear, rect);
     let block = panel(&format!("signal · {}", target), theme);
     let inner = block.inner(rect);
     f.render_widget(block, rect);
 
     let mut lines: Vec<Line> = Vec::new();
-    for (i, (name, num, _)) in crate::app::SIGNALS.iter().enumerate() {
+    for (i, (name, num, _)) in crate::metrics::SIGNALS.iter().enumerate() {
         let selected = i == idx;
         let style = if selected {
             Style::default()
@@ -1522,7 +1522,7 @@ fn render_confirm(f: &mut Frame, area: Rect, theme: &Theme, pk: &crate::app::Pen
         ));
     let inner = block.inner(rect);
     f.render_widget(block, rect);
-    let sig = crate::app::signal_name(pk.signal);
+    let sig = crate::metrics::signal_name(pk.signal);
     let lines = vec![
         Line::from(vec![
             Span::styled("Send ", Style::default().fg(theme.fg.color())),


### PR DESCRIPTION
## Why

Follow-up cleanup on the signal-menu work (#20). A `/simplify` pass with four cleanup agents (reuse, simplification, efficiency, altitude) found one real issue, flagged independently by three of them: the same 9-signal mapping was encoded in **three** places, and #20 had actively deepened the duplication.

- `SIGNALS` table — `(label, number, Signal)`
- `signal_name()` — `Signal → label`
- `raw_signal()` — `Signal → number`

Adding or renaming a signal meant editing three lists that could silently drift (e.g. a menu signal whose `raw_signal` returns `None` would surface as a spurious "not supported on this platform").

## What changed

- Moved the authoritative `SIGNALS` table down into the `metrics` layer — its natural owner (signal metadata), and it lets `raw_signal` derive from it **without** an upward `metrics → app` dependency.
- `signal_name()` and `raw_signal()` now **derive** from the table via `.find(|(_,_,s)| *s == sig)` (`sysinfo::Signal: Eq`). The two hand-written 9-arm matches are gone; a new signal is now a one-row edit.
- Repointed `app.rs` (import from `metrics`) and `ui/mod.rs` (`crate::metrics::` references).
- Named the battery-poll interval: `const BATTERY_POLL: Duration` instead of a bare `10`.

Net **−14 lines**, no behavior change.

## Deliberately skipped (from the review)
- Redundant `ESRCH => Gone` arm in `signal_process` — kept as documentation of the errno contract.
- Vestigial `&self` on `signal_process` — all agents rated it a minor nit; kept as a method for consistency with `proc_paths` (`Collector` is the OS-interaction facade).

## Verification
`cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` clean · all tests pass (55 + 9 + 3 signal + 1 doctest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)