### PR TITLE
Update tests badge to 68

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-65%20green-success)
+![Tests](https://img.shields.io/badge/tests-68%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 


### PR DESCRIPTION
Refresh the stale README tests badge: 65 → 68, reflecting the 3 signal tests added in #20 (`tests/signals.rs`: delivery, unknown-PID, permission-denied).

Count: 55 unit + 9 render + 3 signal + 1 doctest = 68 (same counting basis as the previous badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)