### PR TITLE
Document signal-menu permission-denied feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ sensors, battery, six themes — all in a single **~1 MB binary with zero runtim
 | 🌈 **Truecolor gradient meters** | CPU (global + per‑core), RAM, swap, disks, GPU and sensors |
 | 🧠 **Interactive process table** | sort 6 ways, tree view, live filter, click‑to‑sort headers, full mouse support |
 | 🔎 **Process detail · I/O** | PPID, threads, RSS/virtual mem, **live disk I/O rates**, exe, cwd; a sortable `DISK` column |
-| ☠️ **Signal menu** | send any of nine signals (`SIGTERM`…`SIGUSR2`) behind a confirmation prompt |
+| ☠️ **Signal menu** | send any of nine signals (`SIGTERM`…`SIGUSR2`) behind a confirmation prompt; the status line distinguishes **delivered** from **permission denied** (signalling another user's process needs `sudo`) and **already‑exited**, so a failed signal explains itself instead of silently doing nothing |
 | 🌐 **Network + connections** | per‑interface rx/tx braille graph; a live TCP/UDP table mapping sockets → process (`n`) |
 | 🗄️ **Disk + sensors** | per‑mount usage, read/write I/O graph, temperatures, battery |
 | 🎨 **Seven themes & layouts** | `gruvbox` · `nord` · `dracula` · `tokyonight` · `matrix` · `cyberpunk` · `paper` (light terminals); `full`/`cpu`/`process` presets |


### PR DESCRIPTION
Documents the signal-outcome behavior shipped in #20: the status line now distinguishes **delivered** / **permission denied** / **already-exited** instead of a blanket "failed".

Verified live in the running app: signalling root-owned PID 1 (`launchd`) as a non-root user shows *"Permission denied signalling launchd (1) — try running as root"* — the case that originally read as "signalling doesn't work".

One-line change to the feature table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)