### PR TITLE
Recolor AI-view hero to match the default gruvbox theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 
 High‑resolution braille graphs, truecolor gradient meters, an interactive process table (tree,
 filter, click‑to‑sort, signal menu), per‑interface network, per‑mount disk + I/O, temperature
-sensors, battery, six themes — all in a single **~1 MB binary with zero runtime dependencies**.
+sensors, battery, seven themes — all in a single **~1 MB binary with zero runtime dependencies**.
 </details>
 
 <details>

--- a/assets/ai-demo.svg
+++ b/assets/ai-demo.svg
@@ -1,35 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 396" width="760" height="396" font-family="ui-monospace,monospace">
-<rect x="2" y="2" width="756" height="392" rx="12" fill="#0d0a1a" stroke="#2de2e6" stroke-width="2"/>
-<circle cx="28" cy="30" r="6" fill="#ff5f56"/><circle cx="48" cy="30" r="6" fill="#ffbd2e"/><circle cx="68" cy="30" r="6" fill="#27c93f"/>
-<text x="380.0" y="36" fill="#2de2e6" font-size="17" font-weight="bold" text-anchor="middle" font-family="ui-monospace,Menlo,Consolas,monospace" >toptop · AI / local-LLM GPU view</text>
-<text x="28" y="74" fill="#ff2975" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ ALERTS<animate attributeName="opacity" values="1;0.35;1" dur="1.1s" repeatCount="indefinite"/></text>
-<text x="120" y="74" fill="#dcebff" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >[warn] gpu0 VRAM 96% — risk of spilling to RAM (5–20× slower)</text>
-<text x="28" y="112" fill="#9fe7ff" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >gpu0  NVIDIA GeForce RTX 4090</text>
-<text x="732" y="112" fill="#8a78b8" font-size="15" font-weight="normal" text-anchor="end" font-family="ui-monospace,Menlo,Consolas,monospace" >312 / 450 W    71°C</text>
-<text x="40" y="152" fill="#8a78b8" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >compute</text>
-<rect x="188" y="140" width="372" height="16" rx="3" fill="#241a38"/>
-<rect x="188" y="140" width="115" height="16" rx="3" fill="#2de2e6"></rect>
-<text x="574" y="152" fill="#2de2e6" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >31%</text>
-<text x="40" y="188" fill="#8a78b8" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >mem b/w</text>
-<rect x="188" y="176" width="372" height="16" rx="3" fill="#241a38"/>
-<rect x="188" y="176" width="290" height="16" rx="3" fill="#ff2e97"><animate attributeName="width" values="260;319;275;305;260" dur="3.6s" keyTimes="0;0.25;0.5;0.75;1" calcMode="spline" keySplines=".4 0 .6 1;.4 0 .6 1;.4 0 .6 1;.4 0 .6 1" repeatCount="indefinite"/></rect>
-<text x="574" y="188" fill="#ff2e97" font-size="15" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >← bottleneck</text>
-<text x="40" y="224" fill="#8a78b8" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vram</text>
-<rect x="188" y="212" width="372" height="16" rx="3" fill="#241a38"/>
-<rect x="188" y="212" width="312" height="16" rx="3" fill="#2bd576"><animate attributeName="width" values="312;360;360;312" dur="6.0s" keyTimes="0;0.5;0.85;1" calcMode="spline" keySplines=".5 0 .5 1;.5 0 .5 1;.5 0 .5 1" repeatCount="indefinite"/><animate attributeName="fill" values="#2bd576;#ffd319;#ff2975;#ff2975;#2bd576" dur="6.0s" keyTimes="0;0.35;0.5;0.85;1" repeatCount="indefinite"/></rect>
-<text x="574" y="224" fill="#8a78b8" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >/ 24 GiB</text>
-<text x="188" y="252" fill="#ff2975" font-size="14" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ near VRAM limit — models will spill to system RAM<animate attributeName="opacity" values="0.15;0.15;1;1;0.15" keyTimes="0;0.35;0.5;0.85;1" dur="6s" repeatCount="indefinite"/></text>
-<line x1="28" y1="278" x2="732" y2="278" stroke="#241a38" stroke-width="1"/>
-<text x="28" y="308" fill="#2de2e6" font-size="16" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >Inference servers (auto-discovered)</text>
-<text x="44" y="336" fill="#9fe7ff" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vLLM :8000</text>
-<text x="160" y="336" fill="#8a78b8" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >meta-llama/Llama-3-8B</text>
-<text x="44" y="372" fill="#2bd576" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">80.6<animate attributeName="opacity" values="1;0;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#2bd576" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">82.3<animate attributeName="opacity" values="0;1;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#2bd576" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">84.1<animate attributeName="opacity" values="0;0;1;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#2bd576" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">85.0<animate attributeName="opacity" values="0;0;0;1;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#2bd576" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">83.2<animate attributeName="opacity" values="0;0;0;0;1;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#2bd576" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">81.4<animate attributeName="opacity" values="0;0;0;0;0;1" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="132" y="372" fill="#2bd576" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >tok/s</text>
-<text x="220" y="372" fill="#8a78b8" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >·  0.29 tok/s/W   ·   kv 64%   ·   req 2/5   ·   ttft 180 ms</text>
-<rect x="720" y="360" width="10" height="18" fill="#2de2e6"><animate attributeName="opacity" values="1;1;0;0" dur="1s" repeatCount="indefinite"/></rect>
+<rect x="2" y="2" width="756" height="392" rx="12" fill="#282828" stroke="#fe8019" stroke-width="2"/>
+<text x="380.0" y="36" fill="#fe8019" font-size="17" font-weight="bold" text-anchor="middle" font-family="ui-monospace,Menlo,Consolas,monospace" >AI · local-LLM GPU view · Esc/a to close</text>
+<text x="28" y="74" fill="#fb4934" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ ALERTS<animate attributeName="opacity" values="1;0.35;1" dur="1.1s" repeatCount="indefinite"/></text>
+<text x="120" y="74" fill="#ebdbb2" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >[warn] gpu0 VRAM 96% — risk of spilling to RAM (5–20× slower)</text>
+<text x="28" y="112" fill="#83a598" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >gpu0  NVIDIA GeForce RTX 4090</text>
+<text x="732" y="112" fill="#928374" font-size="15" font-weight="normal" text-anchor="end" font-family="ui-monospace,Menlo,Consolas,monospace" >312 / 450 W    71°C</text>
+<text x="40" y="152" fill="#928374" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >compute</text>
+<rect x="188" y="140" width="372" height="16" rx="3" fill="#3c3836"/>
+<rect x="188" y="140" width="115" height="16" rx="3" fill="#b8bb26"></rect>
+<text x="574" y="152" fill="#b8bb26" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >31%</text>
+<text x="40" y="188" fill="#928374" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >mem b/w</text>
+<rect x="188" y="176" width="372" height="16" rx="3" fill="#3c3836"/>
+<rect x="188" y="176" width="290" height="16" rx="3" fill="#fe8019"><animate attributeName="width" values="260;319;275;305;260" dur="3.6s" keyTimes="0;0.25;0.5;0.75;1" calcMode="spline" keySplines=".4 0 .6 1;.4 0 .6 1;.4 0 .6 1;.4 0 .6 1" repeatCount="indefinite"/></rect>
+<text x="574" y="188" fill="#fb4934" font-size="15" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >← bottleneck</text>
+<text x="40" y="224" fill="#928374" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vram</text>
+<rect x="188" y="212" width="372" height="16" rx="3" fill="#3c3836"/>
+<rect x="188" y="212" width="312" height="16" rx="3" fill="#b8bb26"><animate attributeName="width" values="312;360;360;312" dur="6.0s" keyTimes="0;0.5;0.85;1" calcMode="spline" keySplines=".5 0 .5 1;.5 0 .5 1;.5 0 .5 1" repeatCount="indefinite"/><animate attributeName="fill" values="#b8bb26;#fabd2f;#fb4934;#fb4934;#b8bb26" dur="6.0s" keyTimes="0;0.35;0.5;0.85;1" repeatCount="indefinite"/></rect>
+<text x="574" y="224" fill="#928374" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >/ 24 GiB</text>
+<text x="188" y="252" fill="#fb4934" font-size="14" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ near VRAM limit — models will spill to system RAM<animate attributeName="opacity" values="0.15;0.15;1;1;0.15" keyTimes="0;0.35;0.5;0.85;1" dur="6s" repeatCount="indefinite"/></text>
+<line x1="28" y1="278" x2="732" y2="278" stroke="#3c3836" stroke-width="1"/>
+<text x="28" y="308" fill="#fe8019" font-size="16" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >Inference servers (auto-discovered)</text>
+<text x="44" y="336" fill="#83a598" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vLLM :8000</text>
+<text x="160" y="336" fill="#928374" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >meta-llama/Llama-3-8B</text>
+<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">80.6<animate attributeName="opacity" values="1;0;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">82.3<animate attributeName="opacity" values="0;1;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">84.1<animate attributeName="opacity" values="0;0;1;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">85.0<animate attributeName="opacity" values="0;0;0;1;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">83.2<animate attributeName="opacity" values="0;0;0;0;1;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">81.4<animate attributeName="opacity" values="0;0;0;0;0;1" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="132" y="372" fill="#b8bb26" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >tok/s</text>
+<text x="220" y="372" fill="#928374" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >·  0.29 tok/s/W   ·   kv 64%   ·   req 2/5   ·   ttft 180 ms</text>
+<rect x="720" y="360" width="10" height="18" fill="#83a598"><animate attributeName="opacity" values="1;1;0;0" dur="1s" repeatCount="indefinite"/></rect>
 </svg>

--- a/scripts/make_ai_demo.py
+++ b/scripts/make_ai_demo.py
@@ -9,11 +9,13 @@ and the spill alert flashes. Re-run after edits:
 import os
 
 W, H = 760, 396
-BG, BORDER = "#0d0a1a", "#2de2e6"
-TEXT, DIM = "#dcebff", "#8a78b8"
-CYAN, MAGENTA = "#2de2e6", "#ff2e97"
-GREEN, RED = "#2bd576", "#ff2975"
-TRACK = "#241a38"
+# Palette mirrors toptop's default `gruvbox` theme (src/theme.rs THEMES[0]) so
+# the hero graphic shows the colors users actually see on first launch.
+BG, BORDER = "#282828", "#fe8019"    # dark bg, accent-orange border
+TEXT, DIM = "#ebdbb2", "#928374"      # body text, dimmed labels
+ACCENT, AQUA = "#fe8019", "#83a598"   # titles/headings (orange), secondary (aqua)
+GREEN, YELLOW, RED = "#b8bb26", "#fabd2f", "#fb4934"  # load-gradient stops
+TRACK = "#3c3836"                     # meter track (selection bg)
 
 BAR_X, BAR_W, BAR_H = 188, 372, 16
 VAL_X = BAR_X + BAR_W + 14
@@ -64,11 +66,8 @@ def main():
     # Panel.
     s.append(f'<rect x="2" y="2" width="{W-4}" height="{H-4}" rx="12" fill="{BG}" '
              f'stroke="{BORDER}" stroke-width="2"/>')
-    # Title bar.
-    s.append('<circle cx="28" cy="30" r="6" fill="#ff5f56"/>'
-             '<circle cx="48" cy="30" r="6" fill="#ffbd2e"/>'
-             '<circle cx="68" cy="30" r="6" fill="#27c93f"/>')
-    s.append(text(W/2, 36, "toptop · AI / local-LLM GPU view", fill=CYAN, size=17,
+    # Title bar — the real view is a bordered panel with no window chrome.
+    s.append(text(W/2, 36, "AI · local-LLM GPU view · Esc/a to close", fill=ACCENT, size=17,
                   weight="bold", anchor="middle"))
 
     # Alert banner (flashing).
@@ -80,27 +79,27 @@ def main():
                   fill=TEXT, size=15))
 
     # GPU line.
-    s.append(text(28, 112, "gpu0  NVIDIA GeForce RTX 4090", fill="#9fe7ff", size=17, weight="bold"))
+    s.append(text(28, 112, "gpu0  NVIDIA GeForce RTX 4090", fill=AQUA, size=17, weight="bold"))
     s.append(text(W-28, 112, "312 / 450 W    71°C", fill=DIM, size=15, anchor="end"))
 
     # compute (static), mem b/w (pulsing), vram (filling to red).
     s.append(text(40, 152, "compute", fill=DIM, size=16))
-    s.append(bar(140, 0.31, CYAN))
-    s.append(text(VAL_X, 152, "31%", fill=CYAN, size=16))
+    s.append(bar(140, 0.31, GREEN))
+    s.append(text(VAL_X, 152, "31%", fill=GREEN, size=16))
 
     s.append(text(40, 188, "mem b/w", fill=DIM, size=16))
     s.append(bar(176, 0.78,
-                 MAGENTA,
+                 ACCENT,
                  animate_w=([0.70, 0.86, 0.74, 0.82, 0.70], 3.6,
                             "0;0.25;0.5;0.75;1", ".4 0 .6 1;.4 0 .6 1;.4 0 .6 1;.4 0 .6 1")))
-    s.append(text(VAL_X, 188, "← bottleneck", fill=MAGENTA, size=15, weight="bold"))
+    s.append(text(VAL_X, 188, "← bottleneck", fill=RED, size=15, weight="bold"))
 
     s.append(text(40, 224, "vram", fill=DIM, size=16))
     s.append(bar(212, 0.84,
                  GREEN,
                  animate_w=([0.84, 0.97, 0.97, 0.84], 6.0, "0;0.5;0.85;1",
                             ".5 0 .5 1;.5 0 .5 1;.5 0 .5 1"),
-                 animate_fill=(f"{GREEN};#ffd319;{RED};{RED};{GREEN}", 6.0, "0;0.35;0.5;0.85;1")))
+                 animate_fill=(f"{GREEN};{YELLOW};{RED};{RED};{GREEN}", 6.0, "0;0.35;0.5;0.85;1")))
     s.append(text(VAL_X, 224, "/ 24 GiB", fill=DIM, size=15))
 
     # Spill warning fades in as VRAM peaks.
@@ -111,15 +110,15 @@ def main():
 
     # Server + ticking tokens/sec.
     s.append(f'<line x1="28" y1="278" x2="{W-28}" y2="278" stroke="{TRACK}" stroke-width="1"/>')
-    s.append(text(28, 308, "Inference servers (auto-discovered)", fill=CYAN, size=16, weight="bold"))
-    s.append(text(44, 336, "vLLM :8000", fill="#9fe7ff", size=17, weight="bold"))
+    s.append(text(28, 308, "Inference servers (auto-discovered)", fill=ACCENT, size=16, weight="bold"))
+    s.append(text(44, 336, "vLLM :8000", fill=AQUA, size=17, weight="bold"))
     s.append(text(160, 336, "meta-llama/Llama-3-8B", fill=DIM, size=15))
     s.append(ticking(44, 372, ["80.6", "82.3", "84.1", "85.0", "83.2", "81.4"]))
     s.append(text(132, 372, "tok/s", fill=GREEN, size=16))
     s.append(text(220, 372, "·  0.29 tok/s/W   ·   kv 64%   ·   req 2/5   ·   ttft 180 ms",
                   fill=DIM, size=15))
     # Blinking cursor.
-    s.append(f'<rect x="{W-40}" y="360" width="10" height="18" fill="{CYAN}">'
+    s.append(f'<rect x="{W-40}" y="360" width="10" height="18" fill="{AQUA}">'
              '<animate attributeName="opacity" values="1;1;0;0" dur="1s" '
              'repeatCount="indefinite"/></rect>')
 


### PR DESCRIPTION
## Why

The `ai-demo.svg` hero graphic used a **cyan/magenta synthwave palette** that doesn't match what users actually see on first launch — the default theme is **`gruvbox`** (`config.rs` → `theme_idx: 0`). The colors in the README didn't reflect the real UI.

## What changed

- Repainted `scripts/make_ai_demo.py`'s palette to gruvbox's **exact** colors from `src/theme.rs` (`THEMES[0]`):
  - bg `#282828` · accent/border/headings `#fe8019` (orange) · body `#ebdbb2` (cream) · device/server names `#83a598` (aqua) · dim labels `#928374` · load gradient `#b8bb26`→`#fabd2f`→`#fb4934` (green→yellow→red)
- Dropped the fake macOS traffic-light window dots — the real AI view is a bordered panel with no window chrome — and matched the panel title text (`AI · local-LLM GPU view · Esc/a to close`).
- Regenerated `assets/ai-demo.svg` (verified valid XML; every color now traces to a gruvbox theme role).
- Fixed a stale caption: **"six themes" → "seven themes"** (`paper` was added).

Verified the render via `qlmanage`, and used the `examples/preview -- … ai` harness as ground truth for the current AI-view layout.

## Scope note

`banner.svg` is **intentionally untouched** — it's separate synthwave *branding* art (distinct from the terminal theme), and it's currently being reworked on another branch, so recoloring it here would collide.

## Preview

Before: cyan/magenta on near-black purple. After: gruvbox — orange accents, cream text, aqua names, green/orange/red meters on `#282828`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)