### PR TITLE
Add macOS to the platform badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![CI](https://github.com/ur-grue/toptop/actions/workflows/ci.yml/badge.svg)](https://github.com/ur-grue/toptop/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/rust-1.82%2B-orange?logo=rust)](https://www.rust-lang.org)
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
-![Platform](https://img.shields.io/badge/platform-linux-informational)
+![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
 ![Tests](https://img.shields.io/badge/tests-68%20green-success)
 


### PR DESCRIPTION
The platform badge read `linux` only; macOS is verified (the app runs and was exercised end-to-end on macOS this session, and a prior commit marked macOS verified). Update the badge to `linux | macOS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)