### PR TITLE
Add CHANGELOG documenting shipped signal-menu work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- **Signal delivery now reports a precise outcome** — *delivered*, *permission
+  denied* (e.g. signalling another user's process without `sudo`), *already
+  exited*, or *unsupported* — instead of a single generic "Failed to signal".
+  The failure reason is read from the real `kill(2)` errno. (#20)
+- **Signal-menu labels:** the confirmation prompt and status line now name all
+  nine signals correctly; `SIGQUIT`, `SIGUSR1`, and `SIGUSR2` were previously
+  mislabeled as `SIGTERM` or shown as a bare "signal". (#20)
+- **Signal numbers** shown in the menu are now platform-correct on macOS
+  (e.g. `SIGSTOP 17`, `SIGUSR1 30`) instead of hardcoded Linux values. (#20)
+- The process table no longer refreshes while a kill confirmation is open, so
+  the selected target can't vanish between prompt and confirm. (#20)
+
+### Changed
+
+- Battery is polled at most once every 10s instead of on every refresh tick,
+  removing repeated `/sys` filesystem I/O from the hot path. (#20)
+- A process's executable path and working directory are resolved on demand for
+  the selected row only, rather than allocated for every process on every
+  refresh. (#20)
+- Internal: signal name and number now derive from a single authoritative
+  `SIGNALS` table. (#21)
+
+### Documentation
+
+- Recolored the AI-view hero graphic to the default `gruvbox` theme so it
+  matches what users see on first launch. (#24)
+- Documented the signal-menu permission-denied behavior. (#23)
+- Added macOS to the platform badge. (#25)
+- Bumped the tests badge to 68. (#22)
+
+## [1.0.1] — 2026-07-06
+
+### Added
+
+- `paper` theme for light terminals.
+- macOS marked as a verified platform.
+
+### Changed
+
+- The repository is now its own Homebrew tap (`Formula/toptop.rb`); documented
+  the third-party-tap trust step.
+
+## [1.0.0] — 2026-07-06
+
+Initial public release.
+
+[Unreleased]: https://github.com/ur-grue/toptop/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/ur-grue/toptop/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/ur-grue/toptop/releases/tag/v1.0.0


### PR DESCRIPTION
Creates `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format) — the repo had none.

- **[Unreleased]** captures everything shipped since v1.0.1: the signal-menu outcome/label/number fixes and the confirm-modal freeze (#20), the perf changes (lazy exe/cwd, throttled battery poll) and single-source `SIGNALS` refactor (#21), and the docs updates — gruvbox hero recolor (#24), permission-denied docs (#23), macOS platform badge (#25), tests badge (#22).
- **[1.0.1]** / **[1.0.0]** baseline entries reconstructed from the existing tags, with compare links.

Filed under `[Unreleased]` rather than bumping the version — say the word if you'd like me to cut a release (`1.0.2` or `1.1.0`) and move the section under a dated heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)