### PR TITLE
Add `--export csv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--export csv` — the top processes as CSV (header row, RFC 4180 quoting) for
+  spreadsheets and `awk`, alongside the existing `json` and `prometheus`
+  exporters. (#16)
+
 ### Fixed
 
 - **Signal delivery now reports a precise outcome** — *delivered*, *permission

--- a/src/export.rs
+++ b/src/export.rs
@@ -239,6 +239,47 @@ pub fn to_json(c: &Collector, top_procs: usize) -> String {
     s
 }
 
+// ── CSV export ─────────────────────────────────────────────────────────────
+
+/// Escape one CSV field per RFC 4180: wrap in double quotes when it contains a
+/// comma, quote, or newline, doubling any embedded quotes.
+fn csv_field(s: &str) -> String {
+    if s.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+/// Render the top processes (highest CPU first, capped at `top_procs`) as CSV
+/// with a header row. CSV is the natural tabular slice for spreadsheets and
+/// `awk`; the full nested snapshot stays in `--export json`.
+pub fn to_csv(c: &Collector, top_procs: usize) -> String {
+    let mut procs: Vec<&_> = c.procs.iter().collect();
+    procs.sort_by(|a, b| {
+        b.cpu
+            .partial_cmp(&a.cpu)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut s = String::with_capacity(top_procs * 64 + 80);
+    s.push_str("pid,name,user,cpu_pct,mem_pct,mem_bytes,io_read_bps,io_write_bps,command\n");
+    for p in procs.iter().take(top_procs) {
+        s.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{}\n",
+            p.pid,
+            csv_field(&p.name),
+            csv_field(&p.user),
+            num(p.cpu as f64),
+            num(p.mem_pct as f64),
+            p.mem_bytes,
+            num(p.io_read_rate),
+            num(p.io_write_rate),
+            csv_field(&p.cmd),
+        ));
+    }
+    s
+}
+
 // ── Prometheus exposition format ───────────────────────────────────────────
 
 /// Sanitize a label value for the Prometheus text format.
@@ -375,6 +416,24 @@ mod tests {
         assert_eq!(num(f64::NAN), "0");
         assert_eq!(num(f64::INFINITY), "0");
         assert_eq!(num(1.5), "1.50");
+    }
+
+    #[test]
+    fn csv_field_escapes_per_rfc4180() {
+        assert_eq!(csv_field("plain"), "plain");
+        assert_eq!(csv_field("a,b"), "\"a,b\"");
+        assert_eq!(csv_field("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(csv_field("two\nlines"), "\"two\nlines\"");
+    }
+
+    #[test]
+    fn csv_has_header_row() {
+        let c = Collector::new(64);
+        let csv = to_csv(&c, 5);
+        assert_eq!(
+            csv.lines().next().unwrap(),
+            "pid,name,user,cpu_pct,mem_pct,mem_bytes,io_read_bps,io_write_bps,command"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ OPTIONS:
         --remote-cmd <C> Command run on each remote (default: toptop --export json)
         --list-themes    Print available themes and exit
         --snapshot       Print a one-shot text snapshot and exit (no TUI)
-        --export <FMT>   Print metrics and exit: 'json' (default) or 'prometheus'
+        --export <FMT>   Print metrics and exit: 'json' (default), 'csv', or 'prometheus'
         --serve-metrics [ADDR]  Run a Prometheus endpoint (default 127.0.0.1:9709)
     -h, --help           Show this help and exit
     -V, --version        Show version and exit
@@ -121,6 +121,10 @@ fn main() -> Result<()> {
                         args.next();
                         "prometheus"
                     }
+                    Some("csv") => {
+                        args.next();
+                        "csv"
+                    }
                     Some("json") => {
                         args.next();
                         "json"
@@ -173,6 +177,7 @@ fn run_export(cfg: &Config, format: &str) -> Result<()> {
     app.on_tick();
     match format {
         "prometheus" => print!("{}", toptop::export::to_prometheus(&app.collector)),
+        "csv" => print!("{}", toptop::export::to_csv(&app.collector, 20)),
         _ => println!("{}", toptop::export::to_json(&app.collector, 20)),
     }
     io::stdout().flush().ok();


### PR DESCRIPTION
Closes #16.

Adds a CSV exporter next to `json`/`prometheus`: the top processes (highest CPU first, same cap as the others) as CSV with a header row and RFC 4180 quoting (`csv_field` handles commas/quotes/newlines in names and command lines).

- `src/export.rs` — `to_csv()` + `csv_field()`, unit tests for the escaping and header.
- `src/main.rs` — `--export csv` arg + dispatch + help text.

```
$ toptop --export csv | head -3
pid,name,user,cpu_pct,mem_pct,mem_bytes,io_read_bps,io_write_bps,command
40269,deleted,snu,25.11,0.13,11255808,2561974.76,0.00,/System/.../deleted
```

Verified live; clippy `-D warnings` + fmt clean; export tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)