### PR TITLE
GPU VRAM column + sort in the process table

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@ pub enum SortField {
     User,
     Time,
     Io,
+    Gpu,
 }
 
 impl SortField {
@@ -33,6 +34,7 @@ impl SortField {
             SortField::User => "USER",
             SortField::Time => "TIME",
             SortField::Io => "DISK",
+            SortField::Gpu => "VRAM",
         }
     }
 
@@ -45,7 +47,8 @@ impl SortField {
             SortField::Name => SortField::User,
             SortField::User => SortField::Time,
             SortField::Time => SortField::Io,
-            SortField::Io => SortField::Cpu,
+            SortField::Io => SortField::Gpu,
+            SortField::Gpu => SortField::Cpu,
         }
     }
 }
@@ -298,6 +301,7 @@ impl App {
                 SortField::Io => io_rate(a)
                     .partial_cmp(&io_rate(b))
                     .unwrap_or(std::cmp::Ordering::Equal),
+                SortField::Gpu => a.gpu_mem.cmp(&b.gpu_mem),
             };
             if self.sort_desc {
                 ord.reverse()
@@ -345,6 +349,7 @@ impl App {
                     SortField::Io => io_rate(pa)
                         .partial_cmp(&io_rate(pb))
                         .unwrap_or(std::cmp::Ordering::Equal),
+                    SortField::Gpu => pa.gpu_mem.cmp(&pb.gpu_mem),
                 };
                 if self.sort_desc {
                     ord.reverse()
@@ -690,8 +695,9 @@ pub fn header_sort_at(rel_x: u16) -> Option<SortField> {
         18..=23 => Some(SortField::Cpu),
         24..=37 => Some(SortField::Mem),
         38..=46 => Some(SortField::Io),
-        47..=54 => Some(SortField::Time),
-        55..=56 => None,
+        47..=54 => Some(SortField::Gpu),
+        55..=62 => Some(SortField::Time),
+        63..=64 => None,
         _ => Some(SortField::Name),
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -103,6 +103,9 @@ pub struct ProcInfo {
     pub status: char,
     pub status_long: &'static str,
     pub threads: usize,
+    /// GPU memory held by this process (bytes), joined from `gpu_procs`; 0 when
+    /// the process holds no VRAM or no GPU is present.
+    pub gpu_mem: u64,
     /// Indentation depth when rendered as a tree (0 when flat).
     pub depth: usize,
 }
@@ -279,6 +282,17 @@ impl Collector {
         let gpu_snap = self.gpu_monitor.snapshot();
         self.gpus = gpu_snap.gpus;
         self.gpu_procs = gpu_snap.procs;
+        // Join per-process VRAM back onto the process list (summing across GPUs)
+        // so the table can show and sort by it. Skipped entirely without a GPU.
+        if !self.gpu_procs.is_empty() {
+            let mut vram: std::collections::HashMap<u32, u64> = std::collections::HashMap::new();
+            for gp in &self.gpu_procs {
+                *vram.entry(gp.pid).or_insert(0) += gp.used_mem;
+            }
+            for p in &mut self.procs {
+                p.gpu_mem = vram.get(&p.pid).copied().unwrap_or(0);
+            }
+        }
         self.servers = self.infer_monitor.snapshot();
         // Battery level moves on the order of minutes; poll it at most this
         // often rather than doing filesystem I/O on every (up to 4×/s) tick.
@@ -470,6 +484,7 @@ impl Collector {
                 status: status_char(status),
                 status_long: status_label(status),
                 threads: proc_.tasks().map(|t| t.len()).unwrap_or(0),
+                gpu_mem: 0,
                 depth: 0,
             });
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -704,6 +704,7 @@ fn render_procs(f: &mut Frame, area: Rect, app: &mut App) {
         Cell::from("MEM%"),
         Cell::from("MEM"),
         Cell::from("DISK"),
+        Cell::from("VRAM"),
         Cell::from("TIME"),
         Cell::from("S"),
         Cell::from("COMMAND"),
@@ -747,6 +748,14 @@ fn render_procs(f: &mut Frame, area: Rect, app: &mut App) {
                     Span::styled("·", dim(theme))
                 }
             }),
+            Cell::from(if p.gpu_mem > 0 {
+                Span::styled(
+                    short_bytes(p.gpu_mem),
+                    Style::default().fg(theme.accent2.color()),
+                )
+            } else {
+                Span::styled("·", dim(theme))
+            }),
             Cell::from(compact_duration(p.run_time)),
             Cell::from(p.status.to_string()),
             Cell::from(cmd),
@@ -771,6 +780,7 @@ fn render_procs(f: &mut Frame, area: Rect, app: &mut App) {
         Constraint::Length(5),
         Constraint::Length(7),
         Constraint::Length(8),
+        Constraint::Length(7),
         Constraint::Length(7),
         Constraint::Length(1),
         Constraint::Min(10),

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -160,9 +160,10 @@ fn header_sort_mapping() {
     assert_eq!(header_sort_at(20), Some(SortField::Cpu));
     assert_eq!(header_sort_at(26), Some(SortField::Mem));
     assert_eq!(header_sort_at(40), Some(SortField::Io));
-    assert_eq!(header_sort_at(50), Some(SortField::Time));
-    assert_eq!(header_sort_at(55), None);
-    assert_eq!(header_sort_at(60), Some(SortField::Name));
+    assert_eq!(header_sort_at(50), Some(SortField::Gpu));
+    assert_eq!(header_sort_at(58), Some(SortField::Time));
+    assert_eq!(header_sort_at(63), None);
+    assert_eq!(header_sort_at(70), Some(SortField::Name));
 }
 
 #[test]


### PR DESCRIPTION
Closes #34.

Brings GPU-heavy processes into the main table so you don't have to open the AI view.

- **Join:** after the GPU snapshot, per-process VRAM (summed across GPUs) from `gpu_procs` is joined onto each `ProcInfo.gpu_mem`. Skipped entirely when no GPU is present, so zero cost on non-GPU machines.
- **Sort:** new `SortField::Gpu` ("VRAM") in the `s` cycle and the click-to-sort header.
- **Render:** a VRAM column between DISK and TIME, showing `·` when a process holds no VRAM (same pattern as the DISK column). `header_sort_at` ranges + its test updated for the shifted columns.

Verified: renders correctly (shows `·` on this GPU-less Mac); the `header_sort_mapping` test guards the click-map alignment; all 68 tests pass; clippy `-D warnings` + fmt clean.

Note: always-on column showing `·` matches the existing DISK behavior; a data-driven / conditional column set is future work (#43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)