### PR TITLE
Add renice (change process priority) from a menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,9 @@ use sysinfo::Signal;
 
 use crate::alerts::{self, Alert, AlertConfig};
 use crate::config::Config;
-use crate::metrics::{signal_name, Collector, Connection, ProcInfo, SignalOutcome, SIGNALS};
+use crate::metrics::{
+    signal_name, Collector, Connection, PriorityOutcome, ProcInfo, SignalOutcome, SIGNALS,
+};
 use crate::theme::{Theme, THEMES};
 
 /// Process table sort columns.
@@ -93,6 +95,18 @@ impl LayoutPreset {
     }
 }
 
+/// Nice-value presets offered by the renice menu (label, value). Lower is
+/// higher priority; negative values need privilege.
+pub const NICE_LEVELS: &[(&str, i32)] = &[
+    ("-20  highest", -20),
+    ("-10", -10),
+    ("-5", -5),
+    ("0  normal", 0),
+    ("5", 5),
+    ("10", 10),
+    ("19  lowest", 19),
+];
+
 /// A pending destructive action awaiting confirmation.
 #[derive(Clone)]
 pub struct PendingKill {
@@ -130,6 +144,8 @@ pub struct App {
     pub pending_kill: Option<PendingKill>,
     /// When `Some`, the signal menu is open with the given highlighted index.
     pub signal_menu: Option<usize>,
+    /// When `Some`, the renice menu is open with the given highlighted index.
+    pub renice_menu: Option<usize>,
     /// Whether the process detail overlay is shown for the selection.
     pub show_detail: bool,
     /// Whether the AI/LLM GPU view is shown.
@@ -173,6 +189,7 @@ impl App {
             proc_rows: 0,
             pending_kill: None,
             signal_menu: None,
+            renice_menu: None,
             show_detail: false,
             show_ai: false,
             show_conn: false,
@@ -463,6 +480,35 @@ impl App {
         }
     }
 
+    /// Open the renice menu for the selected process, highlighting "0 normal".
+    fn open_renice_menu(&mut self) {
+        if self.selected_index().is_some() {
+            self.renice_menu = Some(NICE_LEVELS.iter().position(|&(_, n)| n == 0).unwrap_or(0));
+        }
+    }
+
+    /// Apply the highlighted nice value to the selected process. Renice isn't
+    /// destructive, so it applies directly (no confirmation) and reports the
+    /// outcome in the status line.
+    fn choose_nice(&mut self) {
+        let Some(idx) = self.renice_menu.take() else {
+            return;
+        };
+        let Some((pid, name)) = self.selected_proc().map(|p| (p.pid, p.name.clone())) else {
+            return;
+        };
+        let nice = NICE_LEVELS[idx].1;
+        let msg = match self.collector.set_priority(pid, nice) {
+            PriorityOutcome::Applied => format!("Reniced {} ({}) to {}", name, pid, nice),
+            PriorityOutcome::NotPermitted => format!(
+                "Permission denied renicing {} ({}) — lowering nice needs root",
+                name, pid
+            ),
+            PriorityOutcome::Gone => format!("{} ({}) already exited", name, pid),
+        };
+        self.set_status(msg);
+    }
+
     fn confirm_kill(&mut self) {
         if let Some(pk) = self.pending_kill.take() {
             let sig = signal_name(pk.signal);
@@ -505,6 +551,22 @@ impl App {
                 }
                 KeyCode::Enter => self.choose_signal(),
                 KeyCode::Esc | KeyCode::Char('q') => self.signal_menu = None,
+                _ => {}
+            }
+            return;
+        }
+
+        // Renice menu next.
+        if let Some(idx) = self.renice_menu {
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.renice_menu = Some(idx.saturating_sub(1));
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.renice_menu = Some((idx + 1).min(NICE_LEVELS.len() - 1));
+                }
+                KeyCode::Enter => self.choose_nice(),
+                KeyCode::Esc | KeyCode::Char('q') => self.renice_menu = None,
                 _ => {}
             }
             return;
@@ -627,6 +689,7 @@ impl App {
                 self.set_status("Filter: type to match, Enter to apply, Esc to clear");
             }
             KeyCode::Char('K') | KeyCode::F(9) => self.open_signal_menu(),
+            KeyCode::Char('r') => self.open_renice_menu(),
             KeyCode::Delete => self.request_kill(Signal::Term),
             KeyCode::Char('x') => self.request_kill(Signal::Kill),
             _ => {}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -528,6 +528,24 @@ impl Collector {
         }
     }
 
+    /// Change a process's nice value (scheduling priority). Mirrors
+    /// `signal_process`'s outcome classification via the raw `setpriority(2)`
+    /// errno — raising priority (a lower nice) or renicing another user's
+    /// process needs privilege.
+    pub fn set_priority(&self, pid: u32, nice: i32) -> PriorityOutcome {
+        // SAFETY: setpriority() only inspects its integer arguments; we read
+        // errno via last_os_error() only when it fails.
+        let rc = unsafe { libc::setpriority(libc::PRIO_PROCESS, pid as libc::id_t, nice) };
+        if rc == 0 {
+            return PriorityOutcome::Applied;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::EPERM) | Some(libc::EACCES) => PriorityOutcome::NotPermitted,
+            Some(libc::ESRCH) => PriorityOutcome::Gone,
+            _ => PriorityOutcome::Gone,
+        }
+    }
+
     /// Resolve the executable path and working directory for a single process,
     /// fetched on demand for the detail overlay rather than cached per row.
     pub fn proc_paths(&self, pid: u32) -> (String, String) {
@@ -587,6 +605,17 @@ pub enum SignalOutcome {
     NotPermitted,
     /// The signal isn't supported on this platform.
     Unsupported,
+    /// The process no longer exists.
+    Gone,
+}
+
+/// Outcome of attempting to change a process's nice value.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PriorityOutcome {
+    /// The nice value was set.
+    Applied,
+    /// The caller lacks privilege (raising priority, or another user's process).
+    NotPermitted,
     /// The process no longer exists.
     Gone,
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -49,6 +49,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     if let Some(idx) = app.signal_menu {
         render_signal_menu(f, area, theme, idx, app);
     }
+    if let Some(idx) = app.renice_menu {
+        render_renice_menu(f, area, theme, idx, app);
+    }
     if app.show_help {
         render_help(f, area, theme);
     }
@@ -991,6 +994,41 @@ fn render_signal_menu(f: &mut Frame, area: Rect, theme: &Theme, idx: usize, app:
     f.render_widget(Paragraph::new(Text::from(lines)), inner);
 }
 
+fn render_renice_menu(f: &mut Frame, area: Rect, theme: &Theme, idx: usize, app: &App) {
+    let target = app
+        .selected_proc()
+        .map(|p| format!("{} ({})", truncate(&p.name, 20), p.pid))
+        .unwrap_or_else(|| "process".into());
+    let rect = centered(area, 40, (crate::app::NICE_LEVELS.len() + 3) as u16);
+    f.render_widget(Clear, rect);
+    let block = panel(&format!("renice · {}", target), theme);
+    let inner = block.inner(rect);
+    f.render_widget(block, rect);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, (label, _)) in crate::app::NICE_LEVELS.iter().enumerate() {
+        let selected = i == idx;
+        let style = if selected {
+            Style::default()
+                .bg(theme.selection.color())
+                .fg(theme.accent.color())
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg.color())
+        };
+        let marker = if selected { "▶ " } else { "  " };
+        lines.push(Line::from(Span::styled(
+            format!("{}nice {}", marker, label),
+            style,
+        )));
+    }
+    lines.push(Line::from(Span::styled(
+        "↑/↓ select · Enter apply · Esc cancel",
+        dim(theme),
+    )));
+    f.render_widget(Paragraph::new(Text::from(lines)), inner);
+}
+
 /// The AI / local-LLM view: the GPU metrics that actually predict inference
 /// performance — core vs. memory-bandwidth utilization, VRAM headroom (spill
 /// risk), power/throttle, and which processes hold GPU memory.
@@ -1489,6 +1527,7 @@ fn render_help(f: &mut Frame, area: Rect, theme: &Theme) {
         ("K / F9", "signal menu"),
         ("Del", "terminate (SIGTERM)"),
         ("x", "kill (SIGKILL)"),
+        ("r", "renice (change priority)"),
         ("p / P", "next / prev theme"),
         ("+ / -", "faster / slower refresh"),
         ("space", "pause / resume"),

--- a/tests/renice.rs
+++ b/tests/renice.rs
@@ -1,0 +1,46 @@
+//! Renice: changing a process's scheduling priority.
+
+use std::process::Command;
+
+use toptop::metrics::{Collector, PriorityOutcome};
+
+#[test]
+fn applies_nice_to_owned_process() {
+    let mut child = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn sleep");
+    let pid = child.id();
+
+    let collector = Collector::new(64);
+    // Raising nice (lower priority) on our own child is always permitted.
+    assert_eq!(collector.set_priority(pid, 15), PriorityOutcome::Applied);
+
+    // SAFETY: getpriority only reads the target's nice value.
+    let nice = unsafe { libc::getpriority(libc::PRIO_PROCESS, pid as libc::id_t) };
+    assert_eq!(nice, 15, "nice value should have been applied");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn reports_gone_for_unknown_pid() {
+    let collector = Collector::new(64);
+    assert_eq!(
+        collector.set_priority(0x7FFF_FFF0, 0),
+        PriorityOutcome::Gone
+    );
+}
+
+#[test]
+fn reports_permission_denied_for_foreign_process() {
+    // Root can renice anything, so the guarantee doesn't hold there.
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+    // PID 1 (init/launchd) is root-owned; renicing it as a normal user fails
+    // with EPERM before changing anything.
+    let collector = Collector::new(64);
+    assert_eq!(collector.set_priority(1, -5), PriorityOutcome::NotPermitted);
+}


### PR DESCRIPTION
Closes #41.

Complements the signal menu: press `r` on the selected process to open a nice-value menu (presets -20 … 19). Enter applies immediately.

- **`Collector::set_priority`** — raw `setpriority(2)`, returning `PriorityOutcome` (Applied / NotPermitted / Gone) from the errno, the same pattern as `signal_process`. `EPERM`/`EACCES` → NotPermitted (raising priority or another user's process needs root), `ESRCH` → Gone.
- **UI** — a `renice · <proc>` menu overlay mirroring the signal menu; `r` added to the help overlay.
- Renice isn't destructive, so it applies directly (no kill-style confirmation) and reports the outcome in the status line.

Verified live (tmux): `r` → pick `nice 10` → status *"Reniced sleep (48684) to 10"*. Tests: `tests/renice.rs` (owned process applies + `getpriority` confirms; foreign process → NotPermitted; unknown pid → Gone). Full suite green (71 tests); clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)