### PR TITLE
AI view adapts honestly to the hardware environment

### DIFF
--- a/src/metrics/gpu.rs
+++ b/src/metrics/gpu.rs
@@ -304,6 +304,25 @@ fn query_nvidia_procs() -> Vec<GpuProc> {
     .unwrap_or_default()
 }
 
+/// Human explanation for an empty GPU list, tailored to the build target so
+/// the AI view is honest instead of blank. On Apple Silicon a capable GPU
+/// exists — toptop just has no metrics source for it yet — so this must NOT
+/// claim "no GPU". Exactly one arm compiles per platform.
+pub fn no_gpu_reason() -> &'static str {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "Apple Silicon GPU metrics aren't wired up yet (tracked in ur-grue/toptop#4)."
+    }
+    #[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+    {
+        "No GPU metrics source on this Mac."
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "No GPU metrics source found (needs nvidia-smi, or /sys/class/drm for AMD/Intel)."
+    }
+}
+
 /// Combine all GPU sources: NVIDIA via `nvidia-smi`, AMD/Intel via sysfs.
 fn query_all() -> GpuSnapshot {
     let mut gpus = query_nvidia().unwrap_or_default();
@@ -360,6 +379,20 @@ impl Default for GpuMonitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn no_gpu_reason_is_platform_honest() {
+        let msg = no_gpu_reason();
+        assert!(!msg.is_empty());
+        // On Apple Silicon a GPU exists — the message must not deny that, and
+        // must point at the tracking issue.
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            assert!(msg.contains("Apple Silicon"));
+            assert!(msg.contains("#4"));
+            assert!(!msg.to_lowercase().contains("no gpu"));
+        }
+    }
 
     #[test]
     fn parses_legacy() {

--- a/src/metrics/infer.rs
+++ b/src/metrics/infer.rs
@@ -251,6 +251,21 @@ fn read_proc_text(pid: u32, file: &str) -> Option<String> {
     std::fs::read_to_string(format!("/proc/{pid}/{file}")).ok()
 }
 
+/// Explanation shown when no inference servers were auto-discovered, tailored
+/// to the build target. Localhost discovery walks `/proc`, so it only runs on
+/// Linux today; elsewhere the AI view should say so rather than imply none are
+/// running. Exactly one arm compiles per platform.
+pub fn no_servers_reason() -> &'static str {
+    #[cfg(target_os = "linux")]
+    {
+        "No inference servers found on localhost."
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        "Localhost server discovery is Linux-only (other platforms tracked in ur-grue/toptop#13)."
+    }
+}
+
 /// Discover serving runtimes that are listening, as `(port, pid)`.
 fn discover_servers() -> Vec<(u16, u32)> {
     let mut seen = std::collections::HashSet::new();
@@ -368,6 +383,19 @@ fn scrape_once(prev: &mut HashMap<(u32, u16, &'static str), (f64, Instant)>) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn no_servers_reason_is_platform_honest() {
+        let msg = no_servers_reason();
+        assert!(!msg.is_empty());
+        // Off Linux, discovery doesn't run — the message must say so and point
+        // at the tracking issue rather than implying nothing is running.
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert!(msg.contains("Linux-only"));
+            assert!(msg.contains("#13"));
+        }
+    }
 
     #[test]
     fn splits_and_dechunks() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1032,7 +1032,11 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
 
     if c.gpus.is_empty() {
         lines.push(Line::from(Span::styled(
-            "No GPU detected — showing CPU-based inference below.",
+            crate::metrics::gpu::no_gpu_reason(),
+            dim(theme),
+        )));
+        lines.push(Line::from(Span::styled(
+            "AI workloads and inference servers still show below.",
             dim(theme),
         )));
         lines.push(Line::from(Span::raw("")));
@@ -1230,6 +1234,12 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
                 lines.push(Line::from(stat));
             }
         }
+        lines.push(Line::from(Span::raw("")));
+    } else {
+        lines.push(Line::from(Span::styled(
+            crate::metrics::infer::no_servers_reason(),
+            dim(theme),
+        )));
         lines.push(Line::from(Span::raw("")));
     }
 


### PR DESCRIPTION
First step of the 1.1 focus (own local-inference observability): stop the AI view from lying about the platform.

**Before:** on Apple Silicon, pressing `a` showed *"No GPU detected"* — false (there's a powerful GPU) and it undercuts the tool's headline feature.

**After (platform-aware, honest):**
- `gpu::no_gpu_reason()` — Apple Silicon: *"metrics aren't wired up yet (tracked in #4)"*; Linux: names the missing sources; Intel Mac: no source. Never denies a GPU that exists.
- `infer::no_servers_reason()` — *"Localhost server discovery is Linux-only (other platforms tracked in #13)"* instead of implying nothing runs.
- `render_ai` shows both and still surfaces AI workloads + inference servers.

cfg-gated so exactly one arm compiles per platform. Tests assert the Apple Silicon / non-Linux messages are honest and point to the tracking issues. Verified live on this Apple Silicon Mac. Full suite green (70 tests), clippy `-D warnings` + fmt clean.

Relates to #4 and #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)