### PR TITLE
Apple Silicon GPU utilization (IOKit, no root)

### DIFF
--- a/src/metrics/gpu.rs
+++ b/src/metrics/gpu.rs
@@ -310,7 +310,7 @@ fn query_nvidia_procs() -> Vec<GpuProc> {
 #[cfg(target_os = "macos")]
 mod apple {
     use std::ffi::{c_void, CString};
-    use std::os::raw::{c_char, c_int};
+    use std::os::raw::{c_char, c_int, c_long};
 
     type CFTypeRef = *const c_void;
     type CFStringRef = *const c_void;
@@ -319,14 +319,16 @@ mod apple {
     type IoObject = u32;
 
     const UTF8: u32 = 0x0800_0100; // kCFStringEncodingUTF8
-    const SINT64: c_int = 4; // kCFNumberSInt64Type
+                                   // kCFNumberSInt64Type. CFNumberType is backed by CFIndex (c_long, 64-bit on
+                                   // macOS), so this must be c_long — a c_int here is an FFI ABI mismatch.
+    const SINT64: c_long = 4;
     const NULL_ALLOC: CFAllocatorRef = std::ptr::null();
 
     #[link(name = "CoreFoundation", kind = "framework")]
     extern "C" {
         fn CFStringCreateWithCString(a: CFAllocatorRef, s: *const c_char, enc: u32) -> CFStringRef;
         fn CFDictionaryGetValue(d: CFDictionaryRef, k: *const c_void) -> *const c_void;
-        fn CFNumberGetValue(n: *const c_void, t: c_int, v: *mut c_void) -> bool;
+        fn CFNumberGetValue(n: *const c_void, t: c_long, v: *mut c_void) -> bool;
         fn CFRelease(cf: CFTypeRef);
     }
 

--- a/src/metrics/gpu.rs
+++ b/src/metrics/gpu.rs
@@ -304,11 +304,133 @@ fn query_nvidia_procs() -> Vec<GpuProc> {
     .unwrap_or_default()
 }
 
-/// Combine all GPU sources: NVIDIA via `nvidia-smi`, AMD/Intel via sysfs.
+/// Apple Silicon GPU metrics via IOKit's `IOAccelerator` `PerformanceStatistics`
+/// dictionary — the same no-root source `asitop`/`macmon` read. Raw FFI against
+/// the system CoreFoundation/IOKit frameworks, so we add no crates.
+#[cfg(target_os = "macos")]
+mod apple {
+    use std::ffi::{c_void, CString};
+    use std::os::raw::{c_char, c_int};
+
+    type CFTypeRef = *const c_void;
+    type CFStringRef = *const c_void;
+    type CFDictionaryRef = *const c_void;
+    type CFAllocatorRef = *const c_void;
+    type IoObject = u32;
+
+    const UTF8: u32 = 0x0800_0100; // kCFStringEncodingUTF8
+    const SINT64: c_int = 4; // kCFNumberSInt64Type
+    const NULL_ALLOC: CFAllocatorRef = std::ptr::null();
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringCreateWithCString(a: CFAllocatorRef, s: *const c_char, enc: u32) -> CFStringRef;
+        fn CFDictionaryGetValue(d: CFDictionaryRef, k: *const c_void) -> *const c_void;
+        fn CFNumberGetValue(n: *const c_void, t: c_int, v: *mut c_void) -> bool;
+        fn CFRelease(cf: CFTypeRef);
+    }
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        fn IOServiceMatching(name: *const c_char) -> CFDictionaryRef;
+        fn IOServiceGetMatchingService(main_port: IoObject, matching: CFDictionaryRef) -> IoObject;
+        fn IORegistryEntryCreateCFProperty(
+            entry: IoObject,
+            key: CFStringRef,
+            alloc: CFAllocatorRef,
+            opts: u32,
+        ) -> CFTypeRef;
+        fn IOObjectRelease(obj: IoObject) -> c_int;
+    }
+
+    /// Create a CFString the caller owns (must `CFRelease`). None on failure.
+    unsafe fn cfstr(s: &str) -> Option<CFStringRef> {
+        let c = CString::new(s).ok()?;
+        let r = CFStringCreateWithCString(NULL_ALLOC, c.as_ptr(), UTF8);
+        if r.is_null() {
+            None
+        } else {
+            Some(r)
+        }
+    }
+
+    /// Read an integer from a CFDictionary by string key. The value is borrowed
+    /// (Get-rule), so it is not released here.
+    unsafe fn dict_i64(dict: CFDictionaryRef, key: &str) -> Option<i64> {
+        let k = cfstr(key)?;
+        let val = CFDictionaryGetValue(dict, k);
+        CFRelease(k);
+        if val.is_null() {
+            return None;
+        }
+        let mut out: i64 = 0;
+        let ok = CFNumberGetValue(val, SINT64, &mut out as *mut i64 as *mut c_void);
+        ok.then_some(out)
+    }
+
+    /// GPU core utilization %, or None if IOKit doesn't report it.
+    pub fn utilization() -> Option<f32> {
+        // SAFETY: a standard IOKit registry read. Ownership: the matching dict
+        // is consumed by IOServiceGetMatchingService; the service object and the
+        // Create-rule PerformanceStatistics dict are released here; dictionary
+        // values are Get-rule and not released. Port 0 is kIOMainPortDefault.
+        unsafe {
+            let name = CString::new("IOAccelerator").ok()?;
+            let matching = IOServiceMatching(name.as_ptr());
+            if matching.is_null() {
+                return None;
+            }
+            let service = IOServiceGetMatchingService(0, matching);
+            if service == 0 {
+                return None;
+            }
+            let Some(key) = cfstr("PerformanceStatistics") else {
+                IOObjectRelease(service);
+                return None;
+            };
+            let perf = IORegistryEntryCreateCFProperty(service, key, NULL_ALLOC, 0);
+            CFRelease(key);
+            IOObjectRelease(service);
+            if perf.is_null() {
+                return None;
+            }
+            let util = dict_i64(perf, "Device Utilization %");
+            CFRelease(perf);
+            util.map(|u| u.clamp(0, 100) as f32)
+        }
+    }
+}
+
+/// Apple Silicon GPU as a `Gpu` row: real utilization, no discrete VRAM (unified
+/// memory representation is deferred — see ur-grue/toptop#4).
+#[cfg(target_os = "macos")]
+fn apple_gpus() -> Vec<Gpu> {
+    match apple::utilization() {
+        Some(util) => vec![Gpu {
+            name: "Apple Silicon GPU".to_string(),
+            util_pct: util,
+            has_util: true,
+            mem_util: 0.0,
+            has_mem_util: false,
+            mem_used: 0,
+            mem_total: 0,
+            temp: 0.0,
+            power: 0.0,
+            power_limit: 0.0,
+            throttled: false,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Combine all GPU sources: NVIDIA via `nvidia-smi`, AMD/Intel via sysfs, and
+/// Apple Silicon via IOKit.
 fn query_all() -> GpuSnapshot {
     let mut gpus = query_nvidia().unwrap_or_default();
     let nvidia_present = !gpus.is_empty();
     gpus.extend(read_sysfs_gpus());
+    #[cfg(target_os = "macos")]
+    gpus.extend(apple_gpus());
     let procs = if nvidia_present {
         query_nvidia_procs()
     } else {
@@ -354,6 +476,20 @@ impl GpuMonitor {
 impl Default for GpuMonitor {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod apple_tests {
+    /// The IOKit read must never panic and, when it reports a value, stay in
+    /// range. Accepts None so it's not flaky on Macs/CI without an accelerator.
+    #[test]
+    fn utilization_reads_or_none() {
+        if let Some(u) = super::apple::utilization() {
+            assert!((0.0..=100.0).contains(&u), "util out of range: {u}");
+        }
+        // apple_gpus() must also be panic-free and produce at most one row.
+        assert!(super::apple_gpus().len() <= 1);
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1097,22 +1097,31 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
         }
         lines.push(Line::from(band));
 
-        // VRAM with headroom + spill warning.
-        let mut vram = vec![Span::styled(format!("  {:<10}", "vram"), dim(theme))];
-        vram.extend(graph::meter_spans(mem_pct, bw, theme));
-        vram.push(Span::styled(
-            format!(
-                " {} / {}",
-                human_bytes(g.mem_used),
-                human_bytes(g.mem_total)
-            ),
-            Style::default().fg(theme.grad(mem_pct / 100.0)),
-        ));
-        lines.push(Line::from(vram));
-        if mem_pct >= 90.0 {
+        // VRAM with headroom + spill warning. Apple Silicon has no discrete
+        // VRAM (unified memory) and reports mem_total == 0 — say so honestly
+        // rather than draw a fake 0-byte bar.
+        if g.mem_total > 0 {
+            let mut vram = vec![Span::styled(format!("  {:<10}", "vram"), dim(theme))];
+            vram.extend(graph::meter_spans(mem_pct, bw, theme));
+            vram.push(Span::styled(
+                format!(
+                    " {} / {}",
+                    human_bytes(g.mem_used),
+                    human_bytes(g.mem_total)
+                ),
+                Style::default().fg(theme.grad(mem_pct / 100.0)),
+            ));
+            lines.push(Line::from(vram));
+            if mem_pct >= 90.0 {
+                lines.push(Line::from(Span::styled(
+                    "             ⚠ near VRAM limit — models may spill to RAM (5–20× slower)",
+                    Style::default().fg(theme.grad(1.0)),
+                )));
+            }
+        } else {
             lines.push(Line::from(Span::styled(
-                "             ⚠ near VRAM limit — models may spill to RAM (5–20× slower)",
-                Style::default().fg(theme.grad(1.0)),
+                format!("  {:<10} unified memory (see the memory panel)", "vram"),
+                dim(theme),
             )));
         }
         lines.push(Line::from(Span::raw("")));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1118,9 +1118,16 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
                     Style::default().fg(theme.grad(1.0)),
                 )));
             }
-        } else {
+        } else if g.name.contains("Apple") {
             lines.push(Line::from(Span::styled(
                 format!("  {:<10} unified memory (see the memory panel)", "vram"),
+                dim(theme),
+            )));
+        } else {
+            // Some other GPU that didn't report VRAM total — don't claim it's
+            // unified; just show it's unavailable.
+            lines.push(Line::from(Span::styled(
+                format!("  {:<10} --", "vram"),
                 dim(theme),
             )));
         }


### PR DESCRIPTION
Makes the AI view's headline feature real on Apple Silicon — the 1.1 linchpin (#4).

**What:** reads GPU core utilization from IOKit's `IOAccelerator` → `PerformanceStatistics` → `Device Utilization %` (the same no-root source asitop/macmon use), via **raw FFI against the system CoreFoundation/IOKit frameworks — no new crates**, so the zero-dependency binary stays zero-dependency.

**Verified live on this Apple Silicon Mac:**
```
gpu0  Apple Silicon GPU
  compute   ██████████▌ 35%          ← real, from IOKit
  mem b/w      n/a (needs NVIDIA)
  vram       unified memory (see the memory panel)
```

**Scope (v1):** utilization only. Unified memory has no discrete VRAM, so `mem_total` is 0 and the view says so honestly instead of drawing a fake 0-byte bar. The unified-memory representation and per-process VRAM are the deferred design decisions tracked on #4.

**Safety:** the `unsafe` block follows CF/IOKit ownership rules — Create-rule objects (property dict, CFStrings) released exactly once; Get-rule values not released; the matching dict is consumed by `IOServiceGetMatchingService`; `io_object_t` released; early returns free the service/key. An ultracode adversarial review of the FFI (memory-safety, ABI, threading) is running; I'll fold in anything it confirms.

Non-flaky macOS test (accepts None, asserts range + no panic). Full suite green; clippy `-D warnings` + fmt clean.

Part of #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)