### PR TITLE
ai: detect MLC LLM serve

### DIFF
--- a/src/metrics/ai.rs
+++ b/src/metrics/ai.rs
@@ -48,6 +48,7 @@ const RUNTIMES: &[(&str, &str, AiKind)] = &[
     ("tabbyapi", "TabbyAPI", Serving),
     ("comfyui", "ComfyUI", Serving),
     ("text-generation-webui", "TGW", Serving),
+    ("mlc_llm", "MLC LLM", Serving),
     // ── Training / fine-tuning ───────────────────────────────────────────────
     ("torchrun", "PyTorch", Training),
     ("deepspeed", "DeepSpeed", Training),
@@ -137,4 +138,17 @@ mod tests {
         assert_eq!(inference_runtime("bash", "bash -c 'echo hi'"), None);
         assert_eq!(inference_runtime("svllmx", "/usr/bin/svllmx"), None);
     }
+}
+
+#[test]
+fn detects_mlc_llm() {
+    let r = detect_runtime("mlc_llm", "mlc_llm serve HF://mlc-ai/Llama-3-8B-Instruct").unwrap();
+
+    assert_eq!(r.label, "MLC LLM");
+    assert_eq!(r.kind, AiKind::Serving);
+
+    assert_eq!(
+        inference_runtime("python3", "python3 -m mlc_llm.serve --model ./dist/model"),
+        Some("MLC LLM")
+    );
 }

--- a/src/metrics/ai.rs
+++ b/src/metrics/ai.rs
@@ -138,17 +138,15 @@ mod tests {
         assert_eq!(inference_runtime("bash", "bash -c 'echo hi'"), None);
         assert_eq!(inference_runtime("svllmx", "/usr/bin/svllmx"), None);
     }
-}
 
-#[test]
-fn detects_mlc_llm() {
-    let r = detect_runtime("mlc_llm", "mlc_llm serve HF://mlc-ai/Llama-3-8B-Instruct").unwrap();
-
-    assert_eq!(r.label, "MLC LLM");
-    assert_eq!(r.kind, AiKind::Serving);
-
-    assert_eq!(
-        inference_runtime("python3", "python3 -m mlc_llm.serve --model ./dist/model"),
-        Some("MLC LLM")
-    );
+    #[test]
+    fn detects_mlc_llm() {
+        let r = detect_runtime("mlc_llm", "mlc_llm serve HF://mlc-ai/Llama-3-8B-Instruct").unwrap();
+        assert_eq!(r.label, "MLC LLM");
+        assert_eq!(r.kind, AiKind::Serving);
+        assert_eq!(
+            inference_runtime("python3", "python3 -m mlc_llm.serve --model ./dist/model"),
+            Some("MLC LLM")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds detection for **MLC LLM** inference servers.

### Changes

* Added `mlc_llm` runtime detection to the `RUNTIMES` table.
* Added a unit test covering both:

  * direct `mlc_llm serve`
  * `python -m mlc_llm.serve`

MLC LLM exposes an OpenAI-compatible API but does not expose Prometheus `/metrics`, so this PR only adds runtime detection and does not add a metrics parser.

### Testing

```bash
cargo fmt
cargo test
```

All tests pass on Linux.
