### PR TITLE
Make alert thresholds configurable (config.conf + CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable alert thresholds** — the VRAM-spill, KV-cache-saturation and
+  queue-backlog alert levels can now be tuned via `config.conf`
+  (`alert_vram_pct`, `alert_kv_pct`, `alert_queue`) or CLI flags
+  (`--alert-vram`, `--alert-kv`, `--alert-queue`). The thresholds apply to the
+  TUI banner, `--export prometheus`, and the `--serve-metrics` endpoint. (#6)
 - `--export csv` — the top processes as CSV (header row, RFC 4180 quoting) for
   spreadsheets and `awk`, alongside the existing `json` and `prometheus`
   exporters. (#16)

--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ OPTIONS:
         --snapshot       Print a one‑shot text snapshot and exit (no TUI)
         --export <FMT>   Print metrics and exit: 'json' (default) or 'prometheus'
         --serve-metrics [ADDR]  Run a Prometheus /metrics endpoint (default 127.0.0.1:9709)
+        --alert-vram <PCT>   VRAM % that triggers the spill‑risk alert (default 90)
+        --alert-kv <PCT>     KV‑cache % considered saturated (default 95)
+        --alert-queue <N>    Queued requests considered a backlog (default 8)
     -h, --help           Show help
     -V, --version        Show version
 ```
@@ -385,6 +388,14 @@ cp completions/toptop.fish ~/.config/fish/completions/   # fish
 Settings live at `~/.config/toptop/config.conf` (honoring `XDG_CONFIG_HOME`) and are written
 on exit, so your theme, refresh rate, tree mode and layout persist between runs. CLI flags
 always override the file.
+
+Alert thresholds (VRAM spill, KV‑cache saturation, queue backlog) are tunable there too:
+
+```ini
+alert_vram_pct = 85   # VRAM % that triggers the spill-risk alert (default 90)
+alert_kv_pct = 90     # KV-cache % considered saturated (default 95)
+alert_queue = 4       # queued requests considered a backlog (default 8)
+```
 
 ## 🤝 Contributing
 

--- a/man/toptop.1
+++ b/man/toptop.1
@@ -41,6 +41,15 @@ Run a long-running Prometheus metrics endpoint (default \fI127.0.0.1:9709\fR),
 serving \fB/metrics\fR for continuous scraping. Includes \fBtoptop_alert\fR
 gauges for VRAM-spill, GPU-throttle, KV-cache and queue-backlog conditions.
 .TP
+.BR \-\-alert\-vram " " \fIPCT\fR
+VRAM usage percentage that triggers the spill-risk alert (default 90).
+.TP
+.BR \-\-alert\-kv " " \fIPCT\fR
+KV-cache usage percentage considered saturated (default 95).
+.TP
+.BR \-\-alert\-queue " " \fIN\fR
+Number of queued requests considered a backlog (default 8).
+.TP
 .B \-\-list\-themes
 Print available themes and exit.
 .TP
@@ -110,7 +119,9 @@ Quit.
 .SH FILES
 .TP
 .I ~/.config/toptop/config.conf
-Persisted settings (theme, refresh interval, tree mode, layout). Honors
+Persisted settings (theme, refresh interval, tree mode, layout, alert
+thresholds: \fBalert_vram_pct\fR, \fBalert_kv_pct\fR, \fBalert_queue\fR).
+Honors
 .BR XDG_CONFIG_HOME .
 .SH EXIT STATUS
 Returns 0 on success and 2 on an invalid command-line argument.

--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -163,6 +163,31 @@ mod tests {
     }
 
     #[test]
+    fn custom_thresholds_shift_the_trigger_point() {
+        let mut c = Collector::new(16);
+        c.gpus = vec![gpu(60, 100, false)];
+        c.servers = vec![ServerStats {
+            runtime: "vLLM",
+            port: 8000,
+            kv_pct: Some(80.0),
+            waiting: Some(3.0),
+            ..Default::default()
+        }];
+        // Default thresholds: nothing fires at these levels.
+        assert!(evaluate(&c, &AlertConfig::default()).is_empty());
+        // Tightened thresholds: all three rules fire.
+        let tight = AlertConfig {
+            vram_spill_pct: 50.0,
+            kv_high_pct: 75.0,
+            queue_high: 2.0,
+        };
+        let keys: Vec<_> = evaluate(&c, &tight).iter().map(|x| x.key).collect();
+        assert!(keys.contains(&"vram_spill"));
+        assert!(keys.contains(&"kv_high"));
+        assert!(keys.contains(&"queue_backlog"));
+    }
+
+    #[test]
     fn fires_kv_and_queue() {
         let mut c = Collector::new(16);
         c.servers = vec![ServerStats {

--- a/src/app.rs
+++ b/src/app.rs
@@ -200,7 +200,7 @@ impl App {
             conn_offset: 0,
             conn_rows: 0,
             alerts: Vec::new(),
-            alert_cfg: AlertConfig::default(),
+            alert_cfg: cfg.alerts.clone(),
             status: None,
         };
         app.rebuild_proc_view();
@@ -222,6 +222,7 @@ impl App {
             tree: self.tree,
             per_core: self.per_core,
             layout: self.layout,
+            alerts: self.alert_cfg.clone(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+use crate::alerts::AlertConfig;
 use crate::app::LayoutPreset;
 use crate::theme;
 
@@ -23,6 +24,8 @@ pub struct Config {
     pub per_core: bool,
     /// Body layout preset.
     pub layout: LayoutPreset,
+    /// Alert thresholds (VRAM spill, KV-cache saturation, queue backlog).
+    pub alerts: AlertConfig,
 }
 
 impl Default for Config {
@@ -33,6 +36,7 @@ impl Default for Config {
             tree: false,
             per_core: true,
             layout: LayoutPreset::Full,
+            alerts: AlertConfig::default(),
         }
     }
 }
@@ -48,13 +52,19 @@ impl Config {
 
     /// Load config from disk, ignoring any errors and falling back to defaults.
     pub fn load() -> Self {
-        let mut cfg = Config::default();
         let Some(path) = Self::path() else {
-            return cfg;
+            return Config::default();
         };
         let Ok(contents) = fs::read_to_string(&path) else {
-            return cfg;
+            return Config::default();
         };
+        Self::parse(&contents)
+    }
+
+    /// Parse `key = value` lines, falling back to defaults for anything
+    /// missing or malformed.
+    fn parse(contents: &str) -> Self {
+        let mut cfg = Config::default();
         for line in contents.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') {
@@ -79,6 +89,21 @@ impl Config {
                 "tree" => cfg.tree = parse_bool(value).unwrap_or(cfg.tree),
                 "per_core" => cfg.per_core = parse_bool(value).unwrap_or(cfg.per_core),
                 "layout" => cfg.layout = LayoutPreset::from_name(value).unwrap_or(cfg.layout),
+                "alert_vram_pct" => {
+                    if let Ok(v) = value.parse::<f32>() {
+                        cfg.alerts.vram_spill_pct = v.clamp(1.0, 100.0);
+                    }
+                }
+                "alert_kv_pct" => {
+                    if let Ok(v) = value.parse::<f64>() {
+                        cfg.alerts.kv_high_pct = v.clamp(1.0, 100.0);
+                    }
+                }
+                "alert_queue" => {
+                    if let Ok(v) = value.parse::<f64>() {
+                        cfg.alerts.queue_high = v.max(1.0);
+                    }
+                }
                 _ => {}
             }
         }
@@ -103,12 +128,18 @@ impl Config {
              theme = {}\n\
              tree = {}\n\
              per_core = {}\n\
-             layout = {}\n",
+             layout = {}\n\
+             alert_vram_pct = {}\n\
+             alert_kv_pct = {}\n\
+             alert_queue = {}\n",
             self.tick_ms,
             theme_name,
             self.tree,
             self.per_core,
-            self.layout.label()
+            self.layout.label(),
+            self.alerts.vram_spill_pct,
+            self.alerts.kv_high_pct,
+            self.alerts.queue_high
         );
         let _ = fs::write(path, body);
     }
@@ -131,6 +162,30 @@ mod tests {
         let c = Config::default();
         assert!(c.tick_ms >= 100);
         assert!(c.theme_idx < theme::THEMES.len());
+    }
+
+    #[test]
+    fn parses_alert_thresholds() {
+        let cfg = Config::parse(
+            "alert_vram_pct = 85\n\
+             alert_kv_pct = 90.5\n\
+             alert_queue = 4\n",
+        );
+        assert_eq!(cfg.alerts.vram_spill_pct, 85.0);
+        assert_eq!(cfg.alerts.kv_high_pct, 90.5);
+        assert_eq!(cfg.alerts.queue_high, 4.0);
+    }
+
+    #[test]
+    fn clamps_and_ignores_bad_alert_values() {
+        let cfg = Config::parse(
+            "alert_vram_pct = 250\n\
+             alert_kv_pct = -5\n\
+             alert_queue = lots\n",
+        );
+        assert_eq!(cfg.alerts.vram_spill_pct, 100.0);
+        assert_eq!(cfg.alerts.kv_high_pct, 1.0);
+        assert_eq!(cfg.alerts.queue_high, AlertConfig::default().queue_high);
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -292,7 +292,7 @@ fn plabel(s: &str) -> String {
 /// Render a snapshot in Prometheus exposition format so toptop can be scraped
 /// into Grafana/VictoriaMetrics — the local-inference observability layer.
 /// Pair with a tiny `socat`/`while` loop, or scrape `--export json` directly.
-pub fn to_prometheus(c: &Collector) -> String {
+pub fn to_prometheus(c: &Collector, alert_cfg: &AlertConfig) -> String {
     let mut s = String::with_capacity(4096);
     let mut metric = |name: &str, help: &str, value: String| {
         s.push_str(&format!(
@@ -384,7 +384,7 @@ pub fn to_prometheus(c: &Collector) -> String {
     }
 
     // Firing alerts — one gauge per active alert so Alertmanager can page.
-    let alerts = alerts::evaluate(c, &AlertConfig::default());
+    let alerts = alerts::evaluate(c, alert_cfg);
     if !alerts.is_empty() {
         s.push_str("# HELP toptop_alert A firing alert (1 = active).\n# TYPE toptop_alert gauge\n");
         for a in &alerts {
@@ -467,7 +467,7 @@ mod tests {
     #[test]
     fn prometheus_has_core_metrics() {
         let c = Collector::new(64);
-        let p = to_prometheus(&c);
+        let p = to_prometheus(&c, &AlertConfig::default());
         for m in [
             "# TYPE toptop_cpu_usage_percent gauge",
             "toptop_mem_total_bytes ",

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ OPTIONS:
         --snapshot       Print a one-shot text snapshot and exit (no TUI)
         --export <FMT>   Print metrics and exit: 'json' (default), 'csv', or 'prometheus'
         --serve-metrics [ADDR]  Run a Prometheus endpoint (default 127.0.0.1:9709)
+        --alert-vram <PCT>   VRAM % that triggers the spill-risk alert (default 90)
+        --alert-kv <PCT>     KV-cache % considered saturated (default 95)
+        --alert-queue <N>    Queued requests considered a backlog (default 8)
     -h, --help           Show this help and exit
     -V, --version        Show version and exit
 
@@ -113,6 +116,30 @@ fn main() -> Result<()> {
                 };
                 serve_addr = Some(addr);
             }
+            "--alert-vram" => {
+                let v = args
+                    .next()
+                    .context("--alert-vram requires a percentage")?
+                    .parse::<f32>()
+                    .context("--alert-vram value must be a number")?;
+                cfg.alerts.vram_spill_pct = v.clamp(1.0, 100.0);
+            }
+            "--alert-kv" => {
+                let v = args
+                    .next()
+                    .context("--alert-kv requires a percentage")?
+                    .parse::<f64>()
+                    .context("--alert-kv value must be a number")?;
+                cfg.alerts.kv_high_pct = v.clamp(1.0, 100.0);
+            }
+            "--alert-queue" => {
+                let v = args
+                    .next()
+                    .context("--alert-queue requires a count")?
+                    .parse::<f64>()
+                    .context("--alert-queue value must be a number")?;
+                cfg.alerts.queue_high = v.max(1.0);
+            }
             "--snapshot" => snapshot = true,
             "--export" => {
                 // Optional format argument: `json` (default) or `prometheus`.
@@ -176,7 +203,10 @@ fn run_export(cfg: &Config, format: &str) -> Result<()> {
     std::thread::sleep(Duration::from_millis(350));
     app.on_tick();
     match format {
-        "prometheus" => print!("{}", toptop::export::to_prometheus(&app.collector)),
+        "prometheus" => print!(
+            "{}",
+            toptop::export::to_prometheus(&app.collector, &cfg.alerts)
+        ),
         "csv" => print!("{}", toptop::export::to_csv(&app.collector, 20)),
         _ => println!("{}", toptop::export::to_json(&app.collector, 20)),
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -25,6 +25,7 @@ const INDEX: &str = "<!doctype html><title>toptop</title>\
 pub fn run(addr: &str, cfg: &Config) -> std::io::Result<()> {
     let shared = Arc::new(Mutex::new(String::from("# toptop: warming up\n")));
     let interval = Duration::from_millis(cfg.tick_ms.max(1000));
+    let alert_cfg = cfg.alerts.clone();
 
     // Background sampler: owns the Collector, republishes rendered metrics.
     {
@@ -35,7 +36,7 @@ pub fn run(addr: &str, cfg: &Config) -> std::io::Result<()> {
                 let mut c = Collector::new(256);
                 loop {
                     c.refresh();
-                    let text = export::to_prometheus(&c);
+                    let text = export::to_prometheus(&c, &alert_cfg);
                     if let Ok(mut s) = shared.lock() {
                         *s = text;
                     }


### PR DESCRIPTION
Closes #6

The VRAM-spill, KV-cache-saturation and queue-backlog thresholds were fixed defaults in `alerts::AlertConfig` (90% / 95% / 8 queued). This wires them through the existing config system so users can tune them.

## What changed

- **`config.conf` keys** following the existing `key = value` pattern:
  ```ini
  alert_vram_pct = 85
  alert_kv_pct = 90
  alert_queue = 4
  ```
  Values are clamped to sane ranges (percentages to 1–100, queue to ≥1); malformed values fall back to defaults, matching how `tick_ms` behaves.
- **CLI flags** `--alert-vram <PCT>`, `--alert-kv <PCT>`, `--alert-queue <N>`, documented in `--help`, the man page, and the README.
- `App::alert_cfg` is populated from `Config` instead of `AlertConfig::default()`, and round-trips through `App::config()` so tuned thresholds persist on exit.
- `export::to_prometheus()` now takes the `AlertConfig`, so `--export prometheus` and the `--serve-metrics` endpoint emit `toptop_alert` gauges at the tuned thresholds instead of silently using defaults.

## Tests

- `config.rs`: parsing of the three keys; clamping and rejection of malformed values (`Config::load` was split into a pure `Config::parse` to make this testable).
- `alerts.rs`: a custom-threshold test showing levels that are quiet at defaults fire once thresholds are tightened.

`cargo test` (79 tests) and `cargo clippy --all-targets` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAFeQmXoUsGgXd5NDt7tY