### PR TITLE
Detect more inference runtimes: TensorRT-LLM, MLC LLM, LM Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **More inference runtimes detected** — TensorRT-LLM (`trtllm-serve`,
+  Prometheus metrics incl. KV-cache utilization, queue and TTFT, plus
+  tokens/sec from its counters), MLC LLM (process detection), and LM Studio
+  (process detection plus the loaded model via its `/api/v0/models`
+  endpoint). (#5)
 - **TGI throughput and TTFT** — discovered Text Generation Inference servers
   now show generated and prefill tokens/sec (derived from TGI's cumulative
   per-request histogram sums) and a mean time-to-first-token estimated from

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 > Local LLMs are **memory‑bandwidth bound** once the model is resident, so a GPU at "31% util" can
 > still be your bottleneck. toptop shows **compute vs. bandwidth** side by side, warns **before**
 > VRAM spills to system RAM (a 5–20× slowdown), reads the driver's throttle reasons, and
-> **auto‑discovers your inference servers** (vLLM · llama.cpp · Ollama · TGI) to scrape live
+> **auto‑discovers your inference servers** (vLLM · llama.cpp · Ollama · TGI · TensorRT‑LLM · LM Studio) to scrape live
 > **tokens/sec**, KV‑cache pressure and queue depth — then exports it as JSON **or Prometheus**
 > for Grafana, or fans out across a cluster with the [fleet view](#-multi-host-fleet-view).
 
@@ -108,7 +108,7 @@ sensors, battery, seven themes — all in a single **~1 MB binary with zero runt
 | | |
 |---|---|
 | 🤖 **AI / local‑LLM view** | compute **vs. memory‑bandwidth** util, VRAM spill warning, throttle flag, per‑process VRAM, tokens/sec/watt, serving‑vs‑training detection (press `a`) |
-| 🔭 **Server auto‑discovery** | finds listening vLLM / llama.cpp / Ollama / TGI and scrapes live **tokens/sec**, KV‑cache, queue depth, TTFT — no config |
+| 🔭 **Server auto‑discovery** | finds listening vLLM / llama.cpp / Ollama / TGI / TensorRT‑LLM / LM Studio and scrapes live **tokens/sec**, KV‑cache, queue depth, TTFT — no config |
 | 🎮 **Multi‑vendor GPU** | NVIDIA (`nvidia-smi`) **and** AMD/Intel (`sysfs`), polled off‑thread — util, bandwidth, VRAM, power, temp, throttle |
 | 📡 **Prometheus exporter** | `--serve-metrics` runs a `/metrics` endpoint (or `--export prometheus`) — scrape tokens/sec, VRAM, throttle into Grafana |
 | 🚨 **Threshold alerts** | VRAM‑spill, GPU‑throttle, KV‑cache and queue‑backlog alerts — a red TUI banner **and** `toptop_alert` gauges for Alertmanager |

--- a/man/toptop.1
+++ b/man/toptop.1
@@ -70,7 +70,8 @@ Toggle the process detail view.
 Toggle the AI / local-LLM GPU view: utilization vs. memory bandwidth, VRAM
 headroom, per-process VRAM, throttle, multi-GPU aggregate, auto-discovered
 inference-server metrics (tokens/sec, KV cache, queue, TTFT) scraped from
-llama.cpp/vLLM/TGI/Ollama, and serving/training workload detection.
+llama.cpp/vLLM/TGI/TensorRT-LLM/Ollama/LM Studio, and serving/training
+workload detection.
 .TP
 .B n
 Open the network-connections inspector.

--- a/src/metrics/ai.rs
+++ b/src/metrics/ai.rs
@@ -34,6 +34,10 @@ const RUNTIMES: &[(&str, &str, AiKind)] = &[
     ("llamafile", "llamafile", Serving),
     ("vllm", "vLLM", Serving),
     ("sglang", "SGLang", Serving),
+    ("trtllm-serve", "TensorRT-LLM", Serving),
+    ("tensorrt_llm", "TensorRT-LLM", Serving),
+    ("mlc_llm", "MLC LLM", Serving),
+    ("mlc-llm", "MLC LLM", Serving),
     ("text-generation-server", "TGI", Serving),
     ("tgi", "TGI", Serving),
     ("koboldcpp", "KoboldCpp", Serving),
@@ -41,6 +45,7 @@ const RUNTIMES: &[(&str, &str, AiKind)] = &[
     ("exllama", "ExLlama", Serving),
     ("lmstudio", "LM Studio", Serving),
     ("lm-studio", "LM Studio", Serving),
+    ("lm studio", "LM Studio", Serving),
     ("localai", "LocalAI", Serving),
     ("gpt4all", "GPT4All", Serving),
     ("mlx_lm", "MLX", Serving),
@@ -118,6 +123,27 @@ mod tests {
         assert_eq!(
             inference_runtime("python", "python -m sglang.launch_server"),
             Some("SGLang")
+        );
+    }
+
+    #[test]
+    fn detects_new_serving_runtimes() {
+        assert_eq!(
+            inference_runtime("trtllm-serve", "trtllm-serve model --port 8000"),
+            Some("TensorRT-LLM")
+        );
+        assert_eq!(
+            inference_runtime("python3", "python3 -m tensorrt_llm.commands.serve model"),
+            Some("TensorRT-LLM")
+        );
+        assert_eq!(
+            inference_runtime("python", "python -m mlc_llm serve HF://mlc-ai/Llama-3-8B"),
+            Some("MLC LLM")
+        );
+        // macOS-style process name with a space.
+        assert_eq!(
+            inference_runtime("LM Studio", "/Applications/LM Studio.app/Contents/MacOS/LM Studio"),
+            Some("LM Studio")
         );
     }
 

--- a/src/metrics/ai.rs
+++ b/src/metrics/ai.rs
@@ -142,7 +142,10 @@ mod tests {
         );
         // macOS-style process name with a space.
         assert_eq!(
-            inference_runtime("LM Studio", "/Applications/LM Studio.app/Contents/MacOS/LM Studio"),
+            inference_runtime(
+                "LM Studio",
+                "/Applications/LM Studio.app/Contents/MacOS/LM Studio"
+            ),
             Some("LM Studio")
         );
     }

--- a/src/metrics/infer.rs
+++ b/src/metrics/infer.rs
@@ -682,7 +682,8 @@ mod tests {
             parse_lmstudio_loaded_model(json).as_deref(),
             Some("llama-3.2-3b-instruct")
         );
-        let none_loaded = r#"{"data":[{"id":"a","state":"not-loaded"},{"id":"b","state":"not-loaded"}]}"#;
+        let none_loaded =
+            r#"{"data":[{"id":"a","state":"not-loaded"},{"id":"b","state":"not-loaded"}]}"#;
         assert_eq!(parse_lmstudio_loaded_model(none_loaded), None);
     }
 

--- a/src/metrics/infer.rs
+++ b/src/metrics/infer.rs
@@ -5,8 +5,9 @@
 //! servers and scrape the numbers you actually watch — **tokens/sec**, KV-cache
 //! pressure, queue depth, TTFT — straight from their metrics endpoints.
 //!
-//! Supported: llama.cpp / vLLM / TGI Prometheus `/metrics`, and Ollama's
-//! `/api/ps` JSON. The HTTP client is a tiny hand-rolled localhost GET (no
+//! Supported: llama.cpp / vLLM / TGI / TensorRT-LLM Prometheus `/metrics`,
+//! Ollama's `/api/ps` JSON, and LM Studio's `/api/v0/models` JSON. The HTTP
+//! client is a tiny hand-rolled localhost GET (no
 //! dependencies); scraping runs on a background thread so it never blocks the
 //! UI. The parsers are pure and unit-tested; discovery degrades to nothing when
 //! no server is listening.
@@ -212,6 +213,28 @@ pub fn parse_ollama_ps(json: &str) -> Vec<OllamaModel> {
     out
 }
 
+/// Parse LM Studio's `/api/v0/models` response: the id of the first model in
+/// `"state":"loaded"`, if any. Objects look like
+/// `{"id":"qwen2-vl-7b-instruct", …, "state":"loaded", …}`.
+pub fn parse_lmstudio_loaded_model(json: &str) -> Option<String> {
+    let mut idx = 0;
+    while let Some(rel) = json[idx..].find("\"id\":\"") {
+        let istart = idx + rel + "\"id\":\"".len();
+        let iend = json[istart..].find('"')?;
+        let id = &json[istart..istart + iend];
+        // Bound the state search to this object (before the next "id").
+        let next = json[istart..]
+            .find("\"id\":\"")
+            .map(|p| istart + p)
+            .unwrap_or(json.len());
+        if json[istart..next].contains("\"state\":\"loaded\"") {
+            return Some(id.to_string());
+        }
+        idx = istart + iend;
+    }
+    None
+}
+
 /// Build the gauge-derived part of `ServerStats` from a Prometheus body. Counter
 /// rates (vLLM tokens/sec) are layered on by the monitor, which holds history.
 pub fn stats_from_prometheus(text: &str, pid: u32, port: u16) -> Option<ServerStats> {
@@ -236,6 +259,20 @@ pub fn stats_from_prometheus(text: &str, pid: u32, port: u16) -> Option<ServerSt
         if let (Some(sum), Some(cnt)) = (
             prom_sum(text, "vllm:time_to_first_token_seconds_sum"),
             prom_sum(text, "vllm:time_to_first_token_seconds_count"),
+        ) {
+            if cnt > 0.0 {
+                s.ttft_ms = Some(sum / cnt * 1000.0);
+            }
+        }
+    } else if text.contains("trtllm_") {
+        s.runtime = "TensorRT-LLM";
+        s.kv_pct = prom_sum(text, "trtllm_kv_cache_utilization").map(|v| v * 100.0);
+        s.running = prom_sum(text, "trtllm_num_requests_running");
+        s.waiting = prom_sum(text, "trtllm_num_requests_waiting");
+        s.model = prom_label(text, "trtllm_", "model_name").unwrap_or_default();
+        if let (Some(sum), Some(cnt)) = (
+            prom_sum(text, "trtllm_time_to_first_token_seconds_sum"),
+            prom_sum(text, "trtllm_time_to_first_token_seconds_count"),
         ) {
             if cnt > 0.0 {
                 s.ttft_ms = Some(sum / cnt * 1000.0);
@@ -411,6 +448,14 @@ fn scrape_once(prev: &mut HashMap<(u32, u16, &'static str), (f64, Instant)>) -> 
                             s.prompt_tps = counter_rate(prev, (pid, port, "prompt"), p, now);
                         }
                     }
+                    "TensorRT-LLM" => {
+                        if let Some(g) = prom_sum(&body, "trtllm_generation_tokens_total") {
+                            s.gen_tps = counter_rate(prev, (pid, port, "gen"), g, now);
+                        }
+                        if let Some(p) = prom_sum(&body, "trtllm_prompt_tokens_total") {
+                            s.prompt_tps = counter_rate(prev, (pid, port, "prompt"), p, now);
+                        }
+                    }
                     // TGI has no tokens-total counters; its per-request
                     // histogram sums are cumulative and increment as requests
                     // finish, so their rate is throughput (slightly bursty).
@@ -442,7 +487,21 @@ fn scrape_once(prev: &mut HashMap<(u32, u16, &'static str), (f64, Instant)>) -> 
                         gpu_offload_pct: offload,
                         ..Default::default()
                     });
+                    continue;
                 }
+            }
+        }
+        // LM Studio JSON (no Prometheus endpoint; /api/v0/models lists
+        // models with a "state" field marking the loaded one).
+        if let Some(body) = http_get(port, "/api/v0/models", timeout) {
+            if body.contains("\"state\"") {
+                out.push(ServerStats {
+                    runtime: "LM Studio",
+                    pid,
+                    port,
+                    model: parse_lmstudio_loaded_model(&body).unwrap_or_default(),
+                    ..Default::default()
+                });
             }
         }
     }
@@ -592,6 +651,39 @@ mod tests {
             counter_rate(&mut prev, (1, 3000, "gen"), g0 + 500.0, t1),
             Some(250.0)
         );
+    }
+
+    #[test]
+    fn trtllm_stats() {
+        // Names as emitted by TensorRT-LLM's MetricsCollector
+        // (tensorrt_llm/metrics/collector.py).
+        let text = "trtllm_kv_cache_utilization{model_name=\"nemotron-nano-3\"} 0.42\n\
+                    trtllm_num_requests_running{model_name=\"nemotron-nano-3\"} 3\n\
+                    trtllm_num_requests_waiting{model_name=\"nemotron-nano-3\"} 1\n\
+                    trtllm_time_to_first_token_seconds_sum{model_name=\"nemotron-nano-3\"} 4.0\n\
+                    trtllm_time_to_first_token_seconds_count{model_name=\"nemotron-nano-3\"} 20\n\
+                    trtllm_generation_tokens_total{model_name=\"nemotron-nano-3\"} 12345\n";
+        let s = stats_from_prometheus(text, 13, 8000).unwrap();
+        assert_eq!(s.runtime, "TensorRT-LLM");
+        assert_eq!(s.kv_pct.map(|v| v.round()), Some(42.0));
+        assert_eq!(s.running, Some(3.0));
+        assert_eq!(s.waiting, Some(1.0));
+        assert_eq!(s.model, "nemotron-nano-3");
+        assert_eq!(s.ttft_ms, Some(200.0));
+    }
+
+    #[test]
+    fn lmstudio_models_parse() {
+        // Shape from LM Studio's REST docs (GET /api/v0/models).
+        let json = r#"{"object":"list","data":[
+            {"id":"qwen2-vl-7b-instruct","object":"model","type":"vlm","state":"not-loaded","max_context_length":32768},
+            {"id":"llama-3.2-3b-instruct","object":"model","type":"llm","state":"loaded","max_context_length":131072}]}"#;
+        assert_eq!(
+            parse_lmstudio_loaded_model(json).as_deref(),
+            Some("llama-3.2-3b-instruct")
+        );
+        let none_loaded = r#"{"data":[{"id":"a","state":"not-loaded"},{"id":"b","state":"not-loaded"}]}"#;
+        assert_eq!(parse_lmstudio_loaded_model(none_loaded), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #5

**Stacked on #58** (both touch the parser arms in `stats_from_prometheus` and the counter-rate dispatch in `scrape_once`); the base is `feat/tgi-throughput` and GitHub will retarget this to `main` when #58 merges.

## What changed

- **Detection rows** (`src/metrics/ai.rs`): `trtllm-serve` / `tensorrt_llm` → TensorRT-LLM (catches both the console script and `python -m tensorrt_llm…`), `mlc_llm` / `mlc-llm` → MLC LLM, and `"lm studio"` — the macOS process name contains a space, which the existing `lmstudio`/`lm-studio` needles can't match.
- **TensorRT-LLM metrics** (`src/metrics/infer.rs`): a `trtllm_` Prometheus arm reading KV-cache utilization, running/waiting requests, the `model_name` label, mean TTFT from `trtllm_time_to_first_token_seconds` (it has a real TTFT histogram, unlike TGI), and gen/prefill tokens/sec from `trtllm_{generation,prompt}_tokens_total` through the existing `counter_rate` machinery. Metric names verified against `tensorrt_llm/metrics/collector.py` in the NVIDIA repo.
- **LM Studio scraping**: no Prometheus endpoint, so after the `/metrics` and Ollama probes fail, `scrape_once` tries `/api/v0/models` (response shape from LM Studio's REST API docs) and reports the first model in `"state":"loaded"` via a new pure parser, `parse_lmstudio_loaded_model`.

From the issue's wishlist: llamafile was already in the runtime table, and its `/metrics` is llama.cpp-compatible (`llamacpp:` prefix), so the existing parser covers it.

## Tests

- detection: `trtllm-serve`, `python -m tensorrt_llm.commands.serve`, `python -m mlc_llm serve`, and the macOS `LM Studio` process name
- a TensorRT-LLM payload exercising gauges, the model label, and TTFT (200 ms)
- LM Studio `/api/v0/models` parsing: picks the loaded model, `None` when nothing is loaded

As with #58, verified against upstream source/docs rather than live servers — a sanity check from someone running `trtllm-serve` or LM Studio would be welcome.

`cargo test` (83) and `cargo clippy --all-targets` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAFeQmXoUsGgXd5NDt7tY