### PR TITLE
AI view: tokens/sec and KV-cache history sparklines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI-view trend sparklines** — each discovered inference server now shows
+  nvtop-style braille sparklines of tokens/sec (scaled to its own peak) and
+  KV-cache % (scaled to 100) next to the instantaneous numbers, fed by
+  per-server 256-sample histories that are pruned when a server goes
+  away. (#30)
 - `--export csv` — the top processes as CSV (header row, RFC 4180 quoting) for
   spreadsheets and `awk`, alongside the existing `json` and `prometheus`
   exporters. (#16)

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -162,8 +162,18 @@ pub struct Collector {
     pub gpu_procs: Vec<GpuProc>,
     /// Auto-discovered local inference servers (tokens/sec, KV cache, …).
     pub servers: Vec<ServerStats>,
+    /// Per-server time series (keyed by pid+port) feeding the AI-view
+    /// sparklines; pruned when a server disappears.
+    pub server_history: std::collections::HashMap<(u32, u16), ServerHistory>,
     pub battery: Option<Battery>,
     pub uptime: u64,
+}
+
+/// Tokens/sec and KV-cache trends for one inference server.
+#[derive(Clone, Debug)]
+pub struct ServerHistory {
+    pub tps: History,
+    pub kv: History,
 }
 
 impl Collector {
@@ -247,6 +257,7 @@ impl Collector {
             gpus: Vec::new(),
             gpu_procs: Vec::new(),
             servers: Vec::new(),
+            server_history: std::collections::HashMap::new(),
             battery: None,
             uptime: 0,
         };
@@ -294,6 +305,7 @@ impl Collector {
             }
         }
         self.servers = self.infer_monitor.snapshot();
+        self.update_server_history();
         // Battery level moves on the order of minutes; poll it at most this
         // often rather than doing filesystem I/O on every (up to 4×/s) tick.
         const BATTERY_POLL: Duration = Duration::from_secs(10);
@@ -304,6 +316,25 @@ impl Collector {
         {
             self.battery = read_battery();
             self.last_battery_at = Some(now);
+        }
+    }
+
+    /// Append this tick's tokens/sec and KV% to each live server's history,
+    /// dropping the histories of servers that vanished.
+    fn update_server_history(&mut self) {
+        let live: std::collections::HashSet<(u32, u16)> =
+            self.servers.iter().map(|s| (s.pid, s.port)).collect();
+        self.server_history.retain(|k, _| live.contains(k));
+        for sv in &self.servers {
+            let h = self
+                .server_history
+                .entry((sv.pid, sv.port))
+                .or_insert_with(|| ServerHistory {
+                    tps: History::new(self.history_len),
+                    kv: History::new(self.history_len),
+                });
+            h.tps.push(sv.gen_tps.unwrap_or(0.0));
+            h.kv.push(sv.kv_pct.unwrap_or(0.0));
         }
     }
 
@@ -701,5 +732,36 @@ fn status_char(status: ProcessStatus) -> char {
         ProcessStatus::UninterruptibleDiskSleep => 'D',
         ProcessStatus::Suspended => 'U',
         ProcessStatus::Unknown(_) => '?',
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_history_tracks_and_prunes() {
+        let mut c = Collector::new(16);
+        c.servers = vec![ServerStats {
+            runtime: "vLLM",
+            pid: 1,
+            port: 8000,
+            gen_tps: Some(10.0),
+            kv_pct: Some(50.0),
+            ..Default::default()
+        }];
+        c.update_server_history();
+        c.servers[0].gen_tps = Some(20.0);
+        c.servers[0].kv_pct = None; // metric momentarily absent → recorded as 0
+        c.update_server_history();
+
+        let h = c.server_history.get(&(1, 8000)).expect("history exists");
+        assert_eq!(h.tps.tail(2), vec![10.0, 20.0]);
+        assert_eq!(h.kv.tail(2), vec![50.0, 0.0]);
+
+        // The server disappears → its history is pruned.
+        c.servers.clear();
+        c.update_server_history();
+        assert!(c.server_history.is_empty());
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1297,6 +1297,27 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
             if stat.len() > 1 {
                 lines.push(Line::from(stat));
             }
+
+            // Trend sparklines (nvtop-style): tokens/sec against its own peak,
+            // KV% against 100. One braille row each, side by side.
+            let spark_w = ((inner.width as usize).saturating_sub(16) / 2).min(20);
+            if let Some(h) = c.server_history.get(&(sv.pid, sv.port)) {
+                if h.tps.len() >= 2 && spark_w >= 6 && lines.len() + 1 < cap {
+                    let spark = |series: &[f64], max: f64| -> Vec<Span<'static>> {
+                        graph::braille_graph(series, max, spark_w, 1, theme)
+                            .pop()
+                            .map(|l| l.spans)
+                            .unwrap_or_default()
+                    };
+                    let mut sp = vec![Span::styled("    tok/s ", dim(theme))];
+                    sp.extend(spark(&h.tps.tail(spark_w * 2), h.tps.max()));
+                    if sv.kv_pct.is_some() {
+                        sp.push(Span::styled("  kv ", dim(theme)));
+                        sp.extend(spark(&h.kv.tail(spark_w * 2), 100.0));
+                    }
+                    lines.push(Line::from(sp));
+                }
+            }
         }
         lines.push(Line::from(Span::raw("")));
     } else {

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -130,6 +130,55 @@ fn ai_view_renders() {
 }
 
 #[test]
+fn ai_view_renders_history_sparklines() {
+    use toptop::history::History;
+    use toptop::metrics::ServerHistory;
+
+    let mut app = App::new(&Config::default());
+    app.show_ai = true;
+    app.collector.servers = vec![toptop::metrics::ServerStats {
+        runtime: "vLLM",
+        pid: 4242,
+        port: 8000,
+        model: "meta-llama/Llama-3-8B".into(),
+        gen_tps: Some(83.4),
+        kv_pct: Some(64.0),
+        ..Default::default()
+    }];
+    let mut tps = History::new(64);
+    let mut kv = History::new(64);
+    for i in 0..40 {
+        tps.push(40.0 + (i % 10) as f64 * 5.0);
+        kv.push(30.0 + i as f64);
+    }
+    app.collector
+        .server_history
+        .insert((4242, 8000), ServerHistory { tps, kv });
+
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|f| ui::draw(f, &mut app))
+        .expect("draw must not panic");
+    let content: String = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+    assert!(content.contains("tok/s"), "sparkline label must render");
+    let has_braille = content
+        .chars()
+        .any(|ch| ('\u{2800}'..='\u{28FF}').contains(&ch));
+    assert!(has_braille, "sparkline must draw braille cells");
+
+    // Degenerate sizes must not panic (sparklines are skipped when cramped).
+    render_at(&mut app, 40, 10);
+    render_at(&mut app, 12, 4);
+}
+
+#[test]
 fn layout_presets_render() {
     let mut app = App::new(&Config::default());
     // Cycle through every layout preset and render the full body each time.


### PR DESCRIPTION
Closes #30

The AI view was instantaneous-only. This adds the trend:

- **Collector** (`src/metrics/mod.rs`): a `ServerHistory { tps, kv }` per discovered server — the same 256-sample `History` ring buffer the CPU/mem/net graphs use — keyed by `(pid, port)`, pushed on every refresh in a small `update_server_history()` step, and pruned as soon as a server disappears so dead servers don't leak buffers.
- **AI view** (`src/ui/mod.rs`): one braille sparkline row per server under its stat line, reusing `braille_graph` at height 1 as inline spans (no new graph primitive): tokens/sec scaled against the series' own peak, KV% against a fixed 100. The row is skipped when fewer than 2 samples exist or the panel is too narrow, so cramped layouts stay clean.

```text
  vLLM :8000  meta-llama/Llama-3-8B
    83.4 tok/s (0.29 tok/s/W)  kv 64%  req 2/5  ttft 180ms
    tok/s ⣀⣠⣴⣶⣿⣶⣤⣀⣀⣠⣴⣶⣿  kv ⣀⣀⣠⣠⣤⣤⣴⣴⣶⣶⣾⣿⣿
```

## Tests

- `server_history_tracks_and_prunes` — samples accumulate in order, a momentarily missing metric records as 0, and a vanished server's history is dropped
- `ai_view_renders_history_sparklines` — renders the AI view with an injected history and asserts the `tok/s` label and actual braille cells (U+2800–U+28FF) land in the buffer; degenerate sizes don't panic

`cargo test` (78) and `cargo clippy --all-targets` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAFeQmXoUsGgXd5NDt7tY