### PR TITLE
Detect more inference runtimes: TensorRT-LLM, MLC LLM, LM Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TGI throughput and TTFT** — discovered Text Generation Inference servers
+  now show generated and prefill tokens/sec (derived from TGI's cumulative
+  per-request histogram sums) and a mean time-to-first-token estimated from
+  its pipeline stages (validation + queue wait + prefill), alongside the
+  existing batch-size and queue-depth gauges. (#10)
 - `--export csv` — the top processes as CSV (header row, RFC 4180 quoting) for
   spreadsheets and `awk`, alongside the existing `json` and `prometheus`
   exporters. (#16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **More inference runtimes detected** — TensorRT-LLM (`trtllm-serve`,
+  Prometheus metrics incl. KV-cache utilization, queue and TTFT, plus
+  tokens/sec from its counters), MLC LLM (process detection), and LM Studio
+  (process detection plus the loaded model via its `/api/v0/models`
+  endpoint). (#5)
 - **TGI throughput and TTFT** — discovered Text Generation Inference servers
   now show generated and prefill tokens/sec (derived from TGI's cumulative
   per-request histogram sums) and a mean time-to-first-token estimated from

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 > Local LLMs are **memory‑bandwidth bound** once the model is resident, so a GPU at "31% util" can
 > still be your bottleneck. toptop shows **compute vs. bandwidth** side by side, warns **before**
 > VRAM spills to system RAM (a 5–20× slowdown), reads the driver's throttle reasons, and
-> **auto‑discovers your inference servers** (vLLM · llama.cpp · Ollama · TGI) to scrape live
+> **auto‑discovers your inference servers** (vLLM · llama.cpp · Ollama · TGI · TensorRT‑LLM · LM Studio) to scrape live
 > **tokens/sec**, KV‑cache pressure and queue depth — then exports it as JSON **or Prometheus**
 > for Grafana, or fans out across a cluster with the [fleet view](#-multi-host-fleet-view).
 
@@ -108,7 +108,7 @@ sensors, battery, seven themes — all in a single **~1 MB binary with zero runt
 | | |
 |---|---|
 | 🤖 **AI / local‑LLM view** | compute **vs. memory‑bandwidth** util, VRAM spill warning, throttle flag, per‑process VRAM, tokens/sec/watt, serving‑vs‑training detection (press `a`) |
-| 🔭 **Server auto‑discovery** | finds listening vLLM / llama.cpp / Ollama / TGI and scrapes live **tokens/sec**, KV‑cache, queue depth, TTFT — no config |
+| 🔭 **Server auto‑discovery** | finds listening vLLM / llama.cpp / Ollama / TGI / TensorRT‑LLM / LM Studio and scrapes live **tokens/sec**, KV‑cache, queue depth, TTFT — no config |
 | 🎮 **Multi‑vendor GPU** | NVIDIA (`nvidia-smi`) **and** AMD/Intel (`sysfs`), polled off‑thread — util, bandwidth, VRAM, power, temp, throttle |
 | 📡 **Prometheus exporter** | `--serve-metrics` runs a `/metrics` endpoint (or `--export prometheus`) — scrape tokens/sec, VRAM, throttle into Grafana |
 | 🚨 **Threshold alerts** | VRAM‑spill, GPU‑throttle, KV‑cache and queue‑backlog alerts — a red TUI banner **and** `toptop_alert` gauges for Alertmanager |

--- a/man/toptop.1
+++ b/man/toptop.1
@@ -70,7 +70,8 @@ Toggle the process detail view.
 Toggle the AI / local-LLM GPU view: utilization vs. memory bandwidth, VRAM
 headroom, per-process VRAM, throttle, multi-GPU aggregate, auto-discovered
 inference-server metrics (tokens/sec, KV cache, queue, TTFT) scraped from
-llama.cpp/vLLM/TGI/Ollama, and serving/training workload detection.
+llama.cpp/vLLM/TGI/TensorRT-LLM/Ollama/LM Studio, and serving/training
+workload detection.
 .TP
 .B n
 Open the network-connections inspector.

--- a/src/metrics/ai.rs
+++ b/src/metrics/ai.rs
@@ -34,6 +34,10 @@ const RUNTIMES: &[(&str, &str, AiKind)] = &[
     ("llamafile", "llamafile", Serving),
     ("vllm", "vLLM", Serving),
     ("sglang", "SGLang", Serving),
+    ("trtllm-serve", "TensorRT-LLM", Serving),
+    ("tensorrt_llm", "TensorRT-LLM", Serving),
+    ("mlc_llm", "MLC LLM", Serving),
+    ("mlc-llm", "MLC LLM", Serving),
     ("text-generation-server", "TGI", Serving),
     ("tgi", "TGI", Serving),
     ("koboldcpp", "KoboldCpp", Serving),
@@ -41,6 +45,7 @@ const RUNTIMES: &[(&str, &str, AiKind)] = &[
     ("exllama", "ExLlama", Serving),
     ("lmstudio", "LM Studio", Serving),
     ("lm-studio", "LM Studio", Serving),
+    ("lm studio", "LM Studio", Serving),
     ("localai", "LocalAI", Serving),
     ("gpt4all", "GPT4All", Serving),
     ("mlx_lm", "MLX", Serving),
@@ -118,6 +123,27 @@ mod tests {
         assert_eq!(
             inference_runtime("python", "python -m sglang.launch_server"),
             Some("SGLang")
+        );
+    }
+
+    #[test]
+    fn detects_new_serving_runtimes() {
+        assert_eq!(
+            inference_runtime("trtllm-serve", "trtllm-serve model --port 8000"),
+            Some("TensorRT-LLM")
+        );
+        assert_eq!(
+            inference_runtime("python3", "python3 -m tensorrt_llm.commands.serve model"),
+            Some("TensorRT-LLM")
+        );
+        assert_eq!(
+            inference_runtime("python", "python -m mlc_llm serve HF://mlc-ai/Llama-3-8B"),
+            Some("MLC LLM")
+        );
+        // macOS-style process name with a space.
+        assert_eq!(
+            inference_runtime("LM Studio", "/Applications/LM Studio.app/Contents/MacOS/LM Studio"),
+            Some("LM Studio")
         );
     }
 

--- a/src/metrics/ai.rs
+++ b/src/metrics/ai.rs
@@ -142,7 +142,10 @@ mod tests {
         );
         // macOS-style process name with a space.
         assert_eq!(
-            inference_runtime("LM Studio", "/Applications/LM Studio.app/Contents/MacOS/LM Studio"),
+            inference_runtime(
+                "LM Studio",
+                "/Applications/LM Studio.app/Contents/MacOS/LM Studio"
+            ),
             Some("LM Studio")
         );
     }

--- a/src/metrics/infer.rs
+++ b/src/metrics/infer.rs
@@ -682,7 +682,8 @@ mod tests {
             parse_lmstudio_loaded_model(json).as_deref(),
             Some("llama-3.2-3b-instruct")
         );
-        let none_loaded = r#"{"data":[{"id":"a","state":"not-loaded"},{"id":"b","state":"not-loaded"}]}"#;
+        let none_loaded =
+            r#"{"data":[{"id":"a","state":"not-loaded"},{"id":"b","state":"not-loaded"}]}"#;
         assert_eq!(parse_lmstudio_loaded_model(none_loaded), None);
     }
 

--- a/src/metrics/infer.rs
+++ b/src/metrics/infer.rs
@@ -5,8 +5,9 @@
 //! servers and scrape the numbers you actually watch — **tokens/sec**, KV-cache
 //! pressure, queue depth, TTFT — straight from their metrics endpoints.
 //!
-//! Supported: llama.cpp / vLLM / TGI Prometheus `/metrics`, and Ollama's
-//! `/api/ps` JSON. The HTTP client is a tiny hand-rolled localhost GET (no
+//! Supported: llama.cpp / vLLM / TGI / TensorRT-LLM Prometheus `/metrics`,
+//! Ollama's `/api/ps` JSON, and LM Studio's `/api/v0/models` JSON. The HTTP
+//! client is a tiny hand-rolled localhost GET (no
 //! dependencies); scraping runs on a background thread so it never blocks the
 //! UI. The parsers are pure and unit-tested; discovery degrades to nothing when
 //! no server is listening.
@@ -212,6 +213,28 @@ pub fn parse_ollama_ps(json: &str) -> Vec<OllamaModel> {
     out
 }
 
+/// Parse LM Studio's `/api/v0/models` response: the id of the first model in
+/// `"state":"loaded"`, if any. Objects look like
+/// `{"id":"qwen2-vl-7b-instruct", …, "state":"loaded", …}`.
+pub fn parse_lmstudio_loaded_model(json: &str) -> Option<String> {
+    let mut idx = 0;
+    while let Some(rel) = json[idx..].find("\"id\":\"") {
+        let istart = idx + rel + "\"id\":\"".len();
+        let iend = json[istart..].find('"')?;
+        let id = &json[istart..istart + iend];
+        // Bound the state search to this object (before the next "id").
+        let next = json[istart..]
+            .find("\"id\":\"")
+            .map(|p| istart + p)
+            .unwrap_or(json.len());
+        if json[istart..next].contains("\"state\":\"loaded\"") {
+            return Some(id.to_string());
+        }
+        idx = istart + iend;
+    }
+    None
+}
+
 /// Build the gauge-derived part of `ServerStats` from a Prometheus body. Counter
 /// rates (vLLM tokens/sec) are layered on by the monitor, which holds history.
 pub fn stats_from_prometheus(text: &str, pid: u32, port: u16) -> Option<ServerStats> {
@@ -236,6 +259,20 @@ pub fn stats_from_prometheus(text: &str, pid: u32, port: u16) -> Option<ServerSt
         if let (Some(sum), Some(cnt)) = (
             prom_sum(text, "vllm:time_to_first_token_seconds_sum"),
             prom_sum(text, "vllm:time_to_first_token_seconds_count"),
+        ) {
+            if cnt > 0.0 {
+                s.ttft_ms = Some(sum / cnt * 1000.0);
+            }
+        }
+    } else if text.contains("trtllm_") {
+        s.runtime = "TensorRT-LLM";
+        s.kv_pct = prom_sum(text, "trtllm_kv_cache_utilization").map(|v| v * 100.0);
+        s.running = prom_sum(text, "trtllm_num_requests_running");
+        s.waiting = prom_sum(text, "trtllm_num_requests_waiting");
+        s.model = prom_label(text, "trtllm_", "model_name").unwrap_or_default();
+        if let (Some(sum), Some(cnt)) = (
+            prom_sum(text, "trtllm_time_to_first_token_seconds_sum"),
+            prom_sum(text, "trtllm_time_to_first_token_seconds_count"),
         ) {
             if cnt > 0.0 {
                 s.ttft_ms = Some(sum / cnt * 1000.0);
@@ -411,6 +448,14 @@ fn scrape_once(prev: &mut HashMap<(u32, u16, &'static str), (f64, Instant)>) -> 
                             s.prompt_tps = counter_rate(prev, (pid, port, "prompt"), p, now);
                         }
                     }
+                    "TensorRT-LLM" => {
+                        if let Some(g) = prom_sum(&body, "trtllm_generation_tokens_total") {
+                            s.gen_tps = counter_rate(prev, (pid, port, "gen"), g, now);
+                        }
+                        if let Some(p) = prom_sum(&body, "trtllm_prompt_tokens_total") {
+                            s.prompt_tps = counter_rate(prev, (pid, port, "prompt"), p, now);
+                        }
+                    }
                     // TGI has no tokens-total counters; its per-request
                     // histogram sums are cumulative and increment as requests
                     // finish, so their rate is throughput (slightly bursty).
@@ -442,7 +487,21 @@ fn scrape_once(prev: &mut HashMap<(u32, u16, &'static str), (f64, Instant)>) -> 
                         gpu_offload_pct: offload,
                         ..Default::default()
                     });
+                    continue;
                 }
+            }
+        }
+        // LM Studio JSON (no Prometheus endpoint; /api/v0/models lists
+        // models with a "state" field marking the loaded one).
+        if let Some(body) = http_get(port, "/api/v0/models", timeout) {
+            if body.contains("\"state\"") {
+                out.push(ServerStats {
+                    runtime: "LM Studio",
+                    pid,
+                    port,
+                    model: parse_lmstudio_loaded_model(&body).unwrap_or_default(),
+                    ..Default::default()
+                });
             }
         }
     }
@@ -592,6 +651,39 @@ mod tests {
             counter_rate(&mut prev, (1, 3000, "gen"), g0 + 500.0, t1),
             Some(250.0)
         );
+    }
+
+    #[test]
+    fn trtllm_stats() {
+        // Names as emitted by TensorRT-LLM's MetricsCollector
+        // (tensorrt_llm/metrics/collector.py).
+        let text = "trtllm_kv_cache_utilization{model_name=\"nemotron-nano-3\"} 0.42\n\
+                    trtllm_num_requests_running{model_name=\"nemotron-nano-3\"} 3\n\
+                    trtllm_num_requests_waiting{model_name=\"nemotron-nano-3\"} 1\n\
+                    trtllm_time_to_first_token_seconds_sum{model_name=\"nemotron-nano-3\"} 4.0\n\
+                    trtllm_time_to_first_token_seconds_count{model_name=\"nemotron-nano-3\"} 20\n\
+                    trtllm_generation_tokens_total{model_name=\"nemotron-nano-3\"} 12345\n";
+        let s = stats_from_prometheus(text, 13, 8000).unwrap();
+        assert_eq!(s.runtime, "TensorRT-LLM");
+        assert_eq!(s.kv_pct.map(|v| v.round()), Some(42.0));
+        assert_eq!(s.running, Some(3.0));
+        assert_eq!(s.waiting, Some(1.0));
+        assert_eq!(s.model, "nemotron-nano-3");
+        assert_eq!(s.ttft_ms, Some(200.0));
+    }
+
+    #[test]
+    fn lmstudio_models_parse() {
+        // Shape from LM Studio's REST docs (GET /api/v0/models).
+        let json = r#"{"object":"list","data":[
+            {"id":"qwen2-vl-7b-instruct","object":"model","type":"vlm","state":"not-loaded","max_context_length":32768},
+            {"id":"llama-3.2-3b-instruct","object":"model","type":"llm","state":"loaded","max_context_length":131072}]}"#;
+        assert_eq!(
+            parse_lmstudio_loaded_model(json).as_deref(),
+            Some("llama-3.2-3b-instruct")
+        );
+        let none_loaded = r#"{"data":[{"id":"a","state":"not-loaded"},{"id":"b","state":"not-loaded"}]}"#;
+        assert_eq!(parse_lmstudio_loaded_model(none_loaded), None);
     }
 
     #[test]

--- a/src/metrics/infer.rs
+++ b/src/metrics/infer.rs
@@ -117,6 +117,36 @@ pub fn prom_sum(text: &str, name: &str) -> Option<f64> {
     found.then_some(total)
 }
 
+/// Like [`prom_sum`], but only over series whose label block contains
+/// `label_frag` (e.g. `method="prefill"`). Returns `None` if none matched.
+pub fn prom_sum_with_label(text: &str, name: &str, label_frag: &str) -> Option<f64> {
+    let mut found = false;
+    let mut total = 0.0;
+    for line in text.lines() {
+        let line = line.trim();
+        if !line.starts_with(name) {
+            continue;
+        }
+        let rest = &line[name.len()..];
+        if !rest.starts_with('{') {
+            continue;
+        }
+        let Some(close) = rest.find('}') else {
+            continue;
+        };
+        if !rest[..close].contains(label_frag) {
+            continue;
+        }
+        if let Some(tok) = rest[close + 1..].split_whitespace().next() {
+            if let Ok(v) = tok.parse::<f64>() {
+                total += v;
+                found = true;
+            }
+        }
+    }
+    found.then_some(total)
+}
+
 /// Extract the first value of `label` from any series of `metric`.
 pub fn prom_label(text: &str, metric: &str, label: &str) -> Option<String> {
     let needle = format!("{label}=\"");
@@ -215,6 +245,31 @@ pub fn stats_from_prometheus(text: &str, pid: u32, port: u16) -> Option<ServerSt
         s.runtime = "TGI";
         s.running = prom_sum(text, "tgi_batch_current_size");
         s.waiting = prom_sum(text, "tgi_queue_size");
+        // TGI exposes no direct TTFT histogram, but TTFT decomposes exactly
+        // into its per-request pipeline stages: validation, queue wait, then
+        // the prefill forward that emits the first token.
+        let mean = |metric: &str| {
+            let sum = prom_sum(text, &format!("{metric}_sum"))?;
+            let cnt = prom_sum(text, &format!("{metric}_count"))?;
+            (cnt > 0.0).then(|| sum / cnt)
+        };
+        let prefill_mean = (|| {
+            let sum = prom_sum_with_label(
+                text,
+                "tgi_batch_inference_duration_sum",
+                "method=\"prefill\"",
+            )?;
+            let cnt = prom_sum_with_label(
+                text,
+                "tgi_batch_inference_duration_count",
+                "method=\"prefill\"",
+            )?;
+            (cnt > 0.0).then(|| sum / cnt)
+        })();
+        if let (Some(queue), Some(prefill)) = (mean("tgi_request_queue_duration"), prefill_mean) {
+            let validation = mean("tgi_request_validation_duration").unwrap_or(0.0);
+            s.ttft_ms = Some((validation + queue + prefill) * 1000.0);
+        }
     } else {
         return None;
     }
@@ -347,13 +402,27 @@ fn scrape_once(prev: &mut HashMap<(u32, u16, &'static str), (f64, Instant)>) -> 
         // Prometheus endpoints (llama.cpp / vLLM / TGI).
         if let Some(body) = http_get(port, "/metrics", timeout) {
             if let Some(mut s) = stats_from_prometheus(&body, pid, port) {
-                if s.runtime == "vLLM" {
-                    if let Some(g) = prom_sum(&body, "vllm:generation_tokens_total") {
-                        s.gen_tps = counter_rate(prev, (pid, port, "gen"), g, now);
+                match s.runtime {
+                    "vLLM" => {
+                        if let Some(g) = prom_sum(&body, "vllm:generation_tokens_total") {
+                            s.gen_tps = counter_rate(prev, (pid, port, "gen"), g, now);
+                        }
+                        if let Some(p) = prom_sum(&body, "vllm:prompt_tokens_total") {
+                            s.prompt_tps = counter_rate(prev, (pid, port, "prompt"), p, now);
+                        }
                     }
-                    if let Some(p) = prom_sum(&body, "vllm:prompt_tokens_total") {
-                        s.prompt_tps = counter_rate(prev, (pid, port, "prompt"), p, now);
+                    // TGI has no tokens-total counters; its per-request
+                    // histogram sums are cumulative and increment as requests
+                    // finish, so their rate is throughput (slightly bursty).
+                    "TGI" => {
+                        if let Some(g) = prom_sum(&body, "tgi_request_generated_tokens_sum") {
+                            s.gen_tps = counter_rate(prev, (pid, port, "gen"), g, now);
+                        }
+                        if let Some(p) = prom_sum(&body, "tgi_request_input_length_sum") {
+                            s.prompt_tps = counter_rate(prev, (pid, port, "prompt"), p, now);
+                        }
                     }
+                    _ => {}
                 }
                 out.push(s);
                 continue;
@@ -444,6 +513,85 @@ mod tests {
         assert_eq!(s.runtime, "vLLM");
         assert_eq!(s.running, Some(3.0));
         assert_eq!(s.kv_pct.map(|v| v.round()), Some(80.0));
+    }
+
+    /// Metric names and shapes as emitted by TGI's router (see
+    /// text-generation-inference `router/src/server.rs`).
+    const TGI_PAYLOAD: &str = "\
+        # TYPE tgi_queue_size gauge\n\
+        tgi_queue_size 2\n\
+        # TYPE tgi_batch_current_size gauge\n\
+        tgi_batch_current_size 1\n\
+        # TYPE tgi_request_validation_duration histogram\n\
+        tgi_request_validation_duration_sum 0.05\n\
+        tgi_request_validation_duration_count 10\n\
+        # TYPE tgi_request_queue_duration histogram\n\
+        tgi_request_queue_duration_sum 1.2\n\
+        tgi_request_queue_duration_count 10\n\
+        # TYPE tgi_batch_inference_duration histogram\n\
+        tgi_batch_inference_duration_sum{method=\"prefill\"} 0.9\n\
+        tgi_batch_inference_duration_count{method=\"prefill\"} 10\n\
+        tgi_batch_inference_duration_sum{method=\"decode\"} 30.0\n\
+        tgi_batch_inference_duration_count{method=\"decode\"} 500\n\
+        # TYPE tgi_request_generated_tokens histogram\n\
+        tgi_request_generated_tokens_sum 1000\n\
+        tgi_request_generated_tokens_count 10\n\
+        # TYPE tgi_request_input_length histogram\n\
+        tgi_request_input_length_sum 5000\n\
+        tgi_request_input_length_count 10\n";
+
+    #[test]
+    fn tgi_stats_with_ttft() {
+        let s = stats_from_prometheus(TGI_PAYLOAD, 12, 3000).unwrap();
+        assert_eq!(s.runtime, "TGI");
+        assert_eq!(s.running, Some(1.0));
+        assert_eq!(s.waiting, Some(2.0));
+        // TTFT = mean validation + mean queue + mean prefill
+        //      = (0.05/10 + 1.2/10 + 0.9/10) s = 215 ms. Decode must not leak in.
+        assert_eq!(s.ttft_ms.map(|v| v.round()), Some(215.0));
+    }
+
+    #[test]
+    fn tgi_ttft_absent_without_prefill_series() {
+        // Queue histogram alone isn't enough to claim a TTFT.
+        let text = "tgi_queue_size 0\n\
+                    tgi_request_queue_duration_sum 1.0\n\
+                    tgi_request_queue_duration_count 10\n";
+        let s = stats_from_prometheus(text, 12, 3000).unwrap();
+        assert_eq!(s.runtime, "TGI");
+        assert_eq!(s.ttft_ms, None);
+    }
+
+    #[test]
+    fn prom_sum_with_label_filters_series() {
+        assert_eq!(
+            prom_sum_with_label(
+                TGI_PAYLOAD,
+                "tgi_batch_inference_duration_sum",
+                "method=\"prefill\""
+            ),
+            Some(0.9)
+        );
+        // Unlabeled series never match a label filter.
+        assert_eq!(
+            prom_sum_with_label(TGI_PAYLOAD, "tgi_queue_size", "method=\"prefill\""),
+            None
+        );
+    }
+
+    #[test]
+    fn tgi_token_counters_feed_the_rate_calc() {
+        // The cumulative histogram sums act as counters for tokens/sec.
+        let mut prev = HashMap::new();
+        let t0 = Instant::now();
+        let g0 = prom_sum(TGI_PAYLOAD, "tgi_request_generated_tokens_sum").unwrap();
+        assert_eq!(counter_rate(&mut prev, (1, 3000, "gen"), g0, t0), None);
+        // 500 more tokens completed over 2s → 250 tok/s.
+        let t1 = t0 + Duration::from_secs(2);
+        assert_eq!(
+            counter_rate(&mut prev, (1, 3000, "gen"), g0 + 500.0, t1),
+            Some(250.0)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #5

Supersedes #59, which GitHub auto-closed (unreopenably) when its stacked base branch was deleted by the #58 merge. Same content, now rebased onto main: since #54 independently added `mlc_llm` detection, this branch drops its duplicate row and keeps the `mlc-llm` hyphen spelling plus everything else — see #59 for the full original description and review.

- Detection rows: `trtllm-serve` / `tensorrt_llm` → TensorRT-LLM, `mlc-llm` → MLC LLM, `"lm studio"` (macOS process name with a space)
- `trtllm_` Prometheus parser arm: KV utilization, running/waiting, `model_name` label, TTFT histogram, tokens/sec counters (names verified against `tensorrt_llm/metrics/collector.py`)
- LM Studio `/api/v0/models` scraping with a pure `parse_lmstudio_loaded_model` parser

`cargo test` (101) and `cargo clippy --all-targets` clean on the merged result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAFeQmXoUsGgXd5NDt7tY