### PR TITLE
Completions for all flags, tests badge, changelog dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-request histogram sums) and a mean time-to-first-token estimated from
   its pipeline stages (validation + queue wait + prefill), alongside the
   existing batch-size and queue-depth gauges. (#10)
-- **TGI throughput and TTFT** — discovered Text Generation Inference servers
-  now show generated and prefill tokens/sec (derived from TGI's cumulative
-  per-request histogram sums) and a mean time-to-first-token estimated from
-  its pipeline stages (validation + queue wait + prefill), alongside the
-  existing batch-size and queue-depth gauges. (#10)
 - **AI-view trend sparklines** — each discovered inference server now shows
   nvtop-style braille sparklines of tokens/sec (scaled to its own peak) and
   KV-cache % (scaled to 100) next to the instantaneous numbers, fed by
@@ -69,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Shell completions (bash/zsh/fish) now cover every flag — `--ai`, `--remote`,
+  `--remote-cmd`, `--config`, `--no-save`, `--export`, `--serve-metrics` and
+  the `--alert-*` family were missing — and the theme list includes
+  `cyberpunk` and `paper`. Tests badge bumped to 113.
 - Recolored the AI-view hero graphic to the default `gruvbox` theme so it
   matches what users see on first launch. (#24)
 - Documented the signal-menu permission-denied behavior. (#23)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-68%20green-success)
+![Tests](https://img.shields.io/badge/tests-113%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 

--- a/completions/_toptop
+++ b/completions/_toptop
@@ -8,8 +8,18 @@ _toptop() {
         '--theme[color theme]:theme:(gruvbox nord dracula tokyonight matrix cyberpunk paper)' \
         '--tree[start in process-tree view]' \
         '--no-tree[start in flat process view]' \
+        '--ai[open the AI / local-LLM GPU view on launch]' \
+        '--remote[multi-host fleet view]:comma-separated SSH hosts:' \
+        '--remote-cmd[command run on each remote]:command:' \
+        '--config[use an explicit config file]:config file:_files' \
+        '--no-save[do not write the config back on exit]' \
         '--list-themes[print available themes and exit]' \
         '--snapshot[print a one-shot text snapshot and exit]' \
+        '--export[print metrics and exit]::format:(json csv prometheus)' \
+        '--serve-metrics[run a Prometheus metrics endpoint]::address:' \
+        '--alert-vram[VRAM % that triggers the spill-risk alert]:percent:' \
+        '--alert-kv[KV-cache % considered saturated]:percent:' \
+        '--alert-queue[queued requests considered a backlog]:count:' \
         '(-h --help)'{-h,--help}'[show help and exit]' \
         '(-V --version)'{-V,--version}'[show version and exit]'
 }

--- a/completions/toptop.bash
+++ b/completions/toptop.bash
@@ -5,15 +5,23 @@ _toptop() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="-t --tick --theme --tree --no-tree --list-themes --snapshot -h --help -V --version"
-    themes="gruvbox nord dracula tokyonight matrix"
+    opts="-t --tick --theme --tree --no-tree --ai --remote --remote-cmd --config --no-save --list-themes --snapshot --export --serve-metrics --alert-vram --alert-kv --alert-queue -h --help -V --version"
+    themes="gruvbox nord dracula tokyonight matrix cyberpunk paper"
 
     case "$prev" in
         --theme)
             COMPREPLY=( $(compgen -W "$themes" -- "$cur") )
             return 0
             ;;
-        -t|--tick)
+        --export)
+            COMPREPLY=( $(compgen -W "json csv prometheus" -- "$cur") )
+            return 0
+            ;;
+        --config)
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0
+            ;;
+        -t|--tick|--remote|--remote-cmd|--serve-metrics|--alert-vram|--alert-kv|--alert-queue)
             return 0
             ;;
     esac

--- a/completions/toptop.fish
+++ b/completions/toptop.fish
@@ -6,7 +6,17 @@ complete -c toptop -s t -l tick -d 'Refresh interval in milliseconds' -r
 complete -c toptop -l theme -d 'Color theme' -xa 'gruvbox nord dracula tokyonight matrix cyberpunk paper'
 complete -c toptop -l tree -d 'Start in process-tree view'
 complete -c toptop -l no-tree -d 'Start in flat process view'
+complete -c toptop -l ai -d 'Open the AI / local-LLM GPU view on launch'
+complete -c toptop -l remote -d 'Multi-host fleet view (comma-separated SSH hosts)' -r
+complete -c toptop -l remote-cmd -d 'Command run on each remote' -r
+complete -c toptop -l config -d 'Use an explicit config file' -rF
+complete -c toptop -l no-save -d 'Do not write the config back on exit'
 complete -c toptop -l list-themes -d 'Print available themes and exit'
 complete -c toptop -l snapshot -d 'Print a one-shot text snapshot and exit'
+complete -c toptop -l export -d 'Print metrics and exit' -xa 'json csv prometheus'
+complete -c toptop -l serve-metrics -d 'Run a Prometheus metrics endpoint'
+complete -c toptop -l alert-vram -d 'VRAM % that triggers the spill-risk alert' -r
+complete -c toptop -l alert-kv -d 'KV-cache % considered saturated' -r
+complete -c toptop -l alert-queue -d 'Queued requests considered a backlog' -r
 complete -c toptop -s h -l help -d 'Show help and exit'
 complete -c toptop -s V -l version -d 'Show version and exit'


### PR DESCRIPTION
Small cleanup flagged during the last review round:

- **Shell completions** (bash/zsh/fish) predated most of the current CLI — `--ai`, `--remote`, `--remote-cmd`, `--config`, `--no-save`, `--export`, `--serve-metrics`, and the `--alert-*` family were missing everywhere, and the bash theme list lacked `cyberpunk`/`paper`. All three now cover every flag, with value completion for theme names, export formats, and `--config` file paths. Bash and zsh files pass their shells' syntax checks.
- **README tests badge** 68 → 113 (the current suite size after this session's PRs).
- **CHANGELOG**: removed a TGI entry that got duplicated during one of the merge-train conflict resolutions.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAFeQmXoUsGgXd5NDt7tY