### PR TITLE
Config-driven customization: user themes, keybindings, columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **User-defined themes** — drop a `.conf` file into
+  `$XDG_CONFIG_HOME/toptop/themes/` and its name joins the built-ins for
+  `--theme`, `--list-themes` and the `p` cycle. `base = <built-in>` supplies
+  every key the file doesn't set, colors are `#rrggbb`, and a broken file
+  warns on stderr and is skipped rather than being fatal. (#17)
+- **Configurable keybindings** — `bind_<action> = <key>[, <key>...]` in the
+  config file remaps any main-view action (`bind_quit = ctrl+x`). Key names
+  cover characters, arrows, `pgup`/`pgdn`, `home`/`end`, `enter`, `space`,
+  `delete`, `f1`–`f12` and `ctrl+`/`alt+` prefixes; unknown keys warn and keep
+  the default, and binding an already-used key moves it. `Esc` and `Ctrl-C`
+  stay fixed. (#42)
+- **Process-table column customization** — the `columns` config key chooses
+  which columns are shown and in which order (`columns = pid, cpu, vram,
+  command`). The header, the row cells and the click-to-sort mapping are all
+  driven by the configured set. (#43)
+
 - **More inference runtimes detected** — TensorRT-LLM (`trtllm-serve`,
   Prometheus metrics incl. KV-cache utilization, queue and TTFT, plus
   tokens/sec from its counters), the `mlc-llm` launcher spelling (base MLC

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-113%20green-success)
+![Tests](https://img.shields.io/badge/tests-129%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 
@@ -321,7 +321,8 @@ toptop [OPTIONS]
 
 OPTIONS:
     -t, --tick <MS>      Refresh interval in milliseconds (100‑60000)
-        --theme <NAME>   Color theme (gruvbox, nord, dracula, tokyonight, matrix, cyberpunk, paper)
+        --theme <NAME>   Color theme (gruvbox, nord, dracula, tokyonight, matrix, cyberpunk,
+                         paper, or a user theme from ~/.config/toptop/themes/<name>.conf)
         --tree           Start in process‑tree view
         --no-tree        Start in flat process view
         --ai             Open the AI / local‑LLM GPU view on launch
@@ -426,6 +427,63 @@ alert_vram_pct = 85   # VRAM % that triggers the spill-risk alert (default 90)
 alert_kv_pct = 90     # KV-cache % considered saturated (default 95)
 alert_queue = 4       # queued requests considered a backlog (default 8)
 ```
+
+### Process-table columns
+
+`columns` chooses which columns the process table shows, in order — drop the ones
+you never read, put `command` first, whatever fits your terminal:
+
+```ini
+columns = pid, cpu, mem%, vram, command
+```
+
+Available: `pid` · `user` · `cpu` · `mem%` · `mem` · `disk` · `vram` · `time` ·
+`state` · `command`. Unknown names are ignored; the header, the rows and
+click‑to‑sort all follow the configured set.
+
+### Keybindings
+
+Every main-view action can be remapped with a `bind_<action>` line. A binding
+replaces the built-in key for that action, and takes a comma-separated list:
+
+```ini
+bind_quit = ctrl+x
+bind_tree = ctrl+t
+bind_up = up, w
+bind_down = down, s
+```
+
+Actions: `quit` · `help` · `pause` · `detail` · `up` · `down` · `page_up` ·
+`page_down` · `first` · `last` · `sort_next` · `sort_invert` · `tree` ·
+`per_core` · `layout` · `connections` · `ai` · `theme_next` · `theme_prev` ·
+`tick_up` · `tick_down` · `filter` · `kill` · `renice` · `sigterm` · `sigkill`.
+
+Key names: single characters (case-sensitive, so `p` and `P` differ), `up`,
+`down`, `left`, `right`, `pgup`, `pgdn`, `home`, `end`, `enter`, `tab`, `space`,
+`backspace`, `delete`, `insert`, `f1`–`f12`, each optionally prefixed with
+`ctrl+` or `alt+`. Unknown keys are reported on stderr and keep the default;
+binding a key that another action already uses moves it (last line wins).
+`Esc` and `Ctrl-C` stay fixed — they are the way out of every overlay.
+
+### User themes
+
+Drop a `.conf` file into `~/.config/toptop/themes/` and its file name becomes a
+theme name for `--theme` and the `p` cycle. `base` picks the built-in every
+unset key falls back to, so a file only states what it changes:
+
+```ini
+# ~/.config/toptop/themes/midnight.conf
+base = nord
+accent = #ff2e97
+accent2 = #00f0ff
+bg = #0d061a          # or `none` to keep the terminal background
+gradient = #00f0ff, #7b61ff, #ff2e97, #ff295a
+```
+
+Keys: `fg` · `bg` · `dim` · `accent` · `accent2` · `border` · `border_focus` ·
+`mem` · `swap` · `net_down` · `net_up` · `disk_read` · `disk_write` ·
+`selection` · `gradient`. Colors are `#rrggbb`. A broken file warns on stderr
+and is skipped — toptop always starts. `--list-themes` marks user themes.
 
 ## 🤝 Contributing
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,10 +8,11 @@ use sysinfo::Signal;
 
 use crate::alerts::{self, Alert, AlertConfig};
 use crate::config::Config;
+use crate::keys::{Action, KeyMap};
 use crate::metrics::{
     signal_name, Collector, Connection, PriorityOutcome, ProcInfo, SignalOutcome, SIGNALS,
 };
-use crate::theme::{Theme, THEMES};
+use crate::theme::{self, Theme};
 
 /// Process table sort columns.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -51,6 +52,116 @@ impl SortField {
             SortField::Time => SortField::Io,
             SortField::Io => SortField::Gpu,
             SortField::Gpu => SortField::Cpu,
+        }
+    }
+}
+
+/// A process-table column.
+///
+/// The configured list drives the header, the row cells and the click-to-sort
+/// mapping in `ui::render_procs` — see the `columns` config key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProcColumn {
+    Pid,
+    User,
+    Cpu,
+    MemPct,
+    Mem,
+    Disk,
+    Vram,
+    Time,
+    State,
+    Command,
+}
+
+/// The column set shown when the config says nothing.
+pub const DEFAULT_COLUMNS: &[ProcColumn] = &[
+    ProcColumn::Pid,
+    ProcColumn::User,
+    ProcColumn::Cpu,
+    ProcColumn::MemPct,
+    ProcColumn::Mem,
+    ProcColumn::Disk,
+    ProcColumn::Vram,
+    ProcColumn::Time,
+    ProcColumn::State,
+    ProcColumn::Command,
+];
+
+impl ProcColumn {
+    /// Config name, also used when the column set is persisted.
+    pub fn name(self) -> &'static str {
+        match self {
+            ProcColumn::Pid => "pid",
+            ProcColumn::User => "user",
+            ProcColumn::Cpu => "cpu",
+            ProcColumn::MemPct => "mem%",
+            ProcColumn::Mem => "mem",
+            ProcColumn::Disk => "disk",
+            ProcColumn::Vram => "vram",
+            ProcColumn::Time => "time",
+            ProcColumn::State => "state",
+            ProcColumn::Command => "command",
+        }
+    }
+
+    /// Header label.
+    pub fn header(self) -> &'static str {
+        match self {
+            ProcColumn::Pid => "PID",
+            ProcColumn::User => "USER",
+            ProcColumn::Cpu => "CPU%",
+            ProcColumn::MemPct => "MEM%",
+            ProcColumn::Mem => "MEM",
+            ProcColumn::Disk => "DISK",
+            ProcColumn::Vram => "VRAM",
+            ProcColumn::Time => "TIME",
+            ProcColumn::State => "S",
+            ProcColumn::Command => "COMMAND",
+        }
+    }
+
+    /// Fixed width in cells, or `None` for the column that takes the rest.
+    pub fn width(self) -> Option<u16> {
+        match self {
+            ProcColumn::Pid => Some(7),
+            ProcColumn::User => Some(9),
+            ProcColumn::Cpu | ProcColumn::MemPct => Some(5),
+            ProcColumn::Mem | ProcColumn::Vram | ProcColumn::Time => Some(7),
+            ProcColumn::Disk => Some(8),
+            ProcColumn::State => Some(1),
+            ProcColumn::Command => None,
+        }
+    }
+
+    /// Sort field a click on this header selects, if the column is sortable.
+    pub fn sort_field(self) -> Option<SortField> {
+        match self {
+            ProcColumn::Pid => Some(SortField::Pid),
+            ProcColumn::User => Some(SortField::User),
+            ProcColumn::Cpu => Some(SortField::Cpu),
+            ProcColumn::MemPct | ProcColumn::Mem => Some(SortField::Mem),
+            ProcColumn::Disk => Some(SortField::Io),
+            ProcColumn::Vram => Some(SortField::Gpu),
+            ProcColumn::Time => Some(SortField::Time),
+            ProcColumn::Command => Some(SortField::Name),
+            ProcColumn::State => None,
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "pid" => Some(ProcColumn::Pid),
+            "user" => Some(ProcColumn::User),
+            "cpu" | "cpu%" => Some(ProcColumn::Cpu),
+            "mem%" | "mempct" => Some(ProcColumn::MemPct),
+            "mem" | "rss" => Some(ProcColumn::Mem),
+            "disk" | "io" => Some(ProcColumn::Disk),
+            "vram" | "gpu" => Some(ProcColumn::Vram),
+            "time" => Some(ProcColumn::Time),
+            "state" | "s" => Some(ProcColumn::State),
+            "command" | "cmd" => Some(ProcColumn::Command),
+            _ => None,
         }
     }
 }
@@ -132,6 +243,10 @@ pub struct App {
 
     pub sort: SortField,
     pub sort_desc: bool,
+    /// Process-table columns, in display order (from the config).
+    pub columns: Vec<ProcColumn>,
+    /// Key → action bindings (from the config).
+    pub keys: KeyMap,
     pub filter: String,
     pub filter_mode: bool,
 
@@ -176,7 +291,7 @@ impl App {
         let collector = Collector::new(history_len);
         let mut app = Self {
             collector,
-            theme_idx: cfg.theme_idx.min(THEMES.len() - 1),
+            theme_idx: cfg.theme_idx.min(theme::themes().len() - 1),
             tick: Duration::from_millis(cfg.tick_ms),
             should_quit: false,
             paused: false,
@@ -186,6 +301,8 @@ impl App {
             layout: cfg.layout,
             sort: SortField::Cpu,
             sort_desc: true,
+            columns: cfg.columns.clone(),
+            keys: cfg.keys.clone(),
             filter: String::new(),
             filter_mode: false,
             proc_view: Vec::new(),
@@ -216,7 +333,7 @@ impl App {
     }
 
     pub fn theme(&self) -> &'static Theme {
-        &THEMES[self.theme_idx]
+        &theme::themes()[self.theme_idx]
     }
 
     /// Snapshot of the config for persistence on exit.
@@ -227,6 +344,9 @@ impl App {
             tree: self.tree,
             per_core: self.per_core,
             layout: self.layout,
+            columns: self.columns.clone(),
+            keys: self.keys.clone(),
+            warnings: Vec::new(),
             alerts: self.alert_cfg.clone(),
         }
     }
@@ -440,7 +560,7 @@ impl App {
     }
 
     fn cycle_theme(&mut self, forward: bool) {
-        let n = THEMES.len();
+        let n = theme::themes().len();
         self.theme_idx = if forward {
             (self.theme_idx + 1) % n
         } else {
@@ -624,90 +744,98 @@ impl App {
 
         // Connections view captures navigation while open.
         if self.show_conn {
-            match key.code {
-                KeyCode::Char('q') => self.should_quit = true,
-                KeyCode::Esc | KeyCode::Char('n') => self.show_conn = false,
-                KeyCode::Up | KeyCode::Char('k') => self.scroll_conn(-1),
-                KeyCode::Down | KeyCode::Char('j') => self.scroll_conn(1),
-                KeyCode::PageUp => self.scroll_conn(-(self.conn_rows.max(1) as isize)),
-                KeyCode::PageDown => self.scroll_conn(self.conn_rows.max(1) as isize),
-                KeyCode::Home | KeyCode::Char('g') => self.conn_offset = 0,
-                KeyCode::End | KeyCode::Char('G') => {
+            if key.code == KeyCode::Esc {
+                self.show_conn = false;
+                return;
+            }
+            match self.keys.action(key) {
+                Some(Action::Quit) => self.should_quit = true,
+                Some(Action::Connections) => self.show_conn = false,
+                Some(Action::Up) => self.scroll_conn(-1),
+                Some(Action::Down) => self.scroll_conn(1),
+                Some(Action::PageUp) => self.scroll_conn(-(self.conn_rows.max(1) as isize)),
+                Some(Action::PageDown) => self.scroll_conn(self.conn_rows.max(1) as isize),
+                Some(Action::First) => self.conn_offset = 0,
+                Some(Action::Last) => {
                     self.conn_offset = self.connections.len().saturating_sub(self.conn_rows.max(1))
                 }
-                KeyCode::Char('p') => self.cycle_theme(true),
+                Some(Action::ThemeNext) => self.cycle_theme(true),
+                Some(Action::ThemePrev) => self.cycle_theme(false),
                 _ => {}
             }
             return;
         }
 
-        match key.code {
-            KeyCode::Char('q') => self.should_quit = true,
-            KeyCode::Esc => {
-                // Esc peels back overlays in order, then clears a filter, then quits.
-                if self.show_ai {
-                    self.show_ai = false;
-                } else if self.show_detail {
-                    self.show_detail = false;
-                } else if !self.filter.is_empty() {
-                    self.filter.clear();
-                    self.rebuild_proc_view();
-                } else {
-                    self.should_quit = true;
-                }
+        // Esc peels back overlays in order, then clears a filter, then quits.
+        // Deliberately not rebindable — it is the way out of every overlay.
+        if key.code == KeyCode::Esc {
+            if self.show_ai {
+                self.show_ai = false;
+            } else if self.show_detail {
+                self.show_detail = false;
+            } else if !self.filter.is_empty() {
+                self.filter.clear();
+                self.rebuild_proc_view();
+            } else {
+                self.should_quit = true;
             }
-            KeyCode::Enter => self.show_detail = !self.show_detail,
-            KeyCode::Char('?') | KeyCode::F(1) => self.show_help = true,
-            KeyCode::Char(' ') => {
+            return;
+        }
+
+        match self.keys.action(key) {
+            Some(Action::Quit) => self.should_quit = true,
+            Some(Action::Detail) => self.show_detail = !self.show_detail,
+            Some(Action::Help) => self.show_help = true,
+            Some(Action::Pause) => {
                 self.paused = !self.paused;
                 self.set_status(if self.paused { "Paused" } else { "Resumed" });
             }
-            KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
-            KeyCode::Down | KeyCode::Char('j') => self.move_selection(1),
-            KeyCode::PageUp => self.move_selection(-(self.proc_rows.max(1) as isize)),
-            KeyCode::PageDown => self.move_selection(self.proc_rows.max(1) as isize),
-            KeyCode::Home | KeyCode::Char('g') => self.select_first(),
-            KeyCode::End | KeyCode::Char('G') => self.select_last(),
-            KeyCode::Char('s') => {
+            Some(Action::Up) => self.move_selection(-1),
+            Some(Action::Down) => self.move_selection(1),
+            Some(Action::PageUp) => self.move_selection(-(self.proc_rows.max(1) as isize)),
+            Some(Action::PageDown) => self.move_selection(self.proc_rows.max(1) as isize),
+            Some(Action::First) => self.select_first(),
+            Some(Action::Last) => self.select_last(),
+            Some(Action::SortNext) => {
                 self.sort = self.sort.next();
                 self.set_status(format!("Sort: {}", self.sort.label()));
                 self.rebuild_proc_view();
             }
-            KeyCode::Char('i') => {
+            Some(Action::SortInvert) => {
                 self.sort_desc = !self.sort_desc;
                 self.rebuild_proc_view();
             }
-            KeyCode::Char('t') => {
+            Some(Action::Tree) => {
                 self.tree = !self.tree;
                 self.set_status(if self.tree { "Tree view" } else { "Flat view" });
                 self.rebuild_proc_view();
             }
-            KeyCode::Char('e') => {
+            Some(Action::PerCore) => {
                 self.per_core = !self.per_core;
             }
-            KeyCode::Char('L') => {
+            Some(Action::Layout) => {
                 self.layout = self.layout.next();
                 self.set_status(format!("Layout: {}", self.layout.label()));
             }
-            KeyCode::Char('n') => {
+            Some(Action::Connections) => {
                 self.show_conn = true;
                 self.conn_offset = 0;
                 self.refresh_connections();
             }
-            KeyCode::Char('a') => self.show_ai = !self.show_ai,
-            KeyCode::Char('p') => self.cycle_theme(true),
-            KeyCode::Char('P') => self.cycle_theme(false),
-            KeyCode::Char('+') | KeyCode::Char('=') => self.adjust_tick(true),
-            KeyCode::Char('-') | KeyCode::Char('_') => self.adjust_tick(false),
-            KeyCode::Char('/') => {
+            Some(Action::Ai) => self.show_ai = !self.show_ai,
+            Some(Action::ThemeNext) => self.cycle_theme(true),
+            Some(Action::ThemePrev) => self.cycle_theme(false),
+            Some(Action::TickUp) => self.adjust_tick(true),
+            Some(Action::TickDown) => self.adjust_tick(false),
+            Some(Action::Filter) => {
                 self.filter_mode = true;
                 self.set_status("Filter: type to match, Enter to apply, Esc to clear");
             }
-            KeyCode::Char('K') | KeyCode::F(9) => self.open_signal_menu(),
-            KeyCode::Char('r') => self.open_renice_menu(),
-            KeyCode::Delete => self.request_kill(Signal::Term),
-            KeyCode::Char('x') => self.request_kill(Signal::Kill),
-            _ => {}
+            Some(Action::Kill) => self.open_signal_menu(),
+            Some(Action::Renice) => self.open_renice_menu(),
+            Some(Action::SigTerm) => self.request_kill(Signal::Term),
+            Some(Action::SigKill) => self.request_kill(Signal::Kill),
+            None => {}
         }
     }
 
@@ -731,7 +859,7 @@ impl App {
                 let area = self.proc_area;
                 // Header row sits one line above the data rows: click to sort.
                 if area.height > 0 && ev.row + 1 == area.y && ev.column >= area.x {
-                    if let Some(field) = header_sort_at(ev.column - area.x) {
+                    if let Some(field) = header_sort_at(&self.columns, ev.column - area.x) {
                         if self.sort == field {
                             self.sort_desc = !self.sort_desc;
                         } else {
@@ -760,19 +888,23 @@ impl App {
 }
 
 /// Map a column-relative x offset on the process header to its sort field.
-/// Ranges mirror the table column widths in `ui::render_procs`.
-pub fn header_sort_at(rel_x: u16) -> Option<SortField> {
-    match rel_x {
-        0..=7 => Some(SortField::Pid),
-        8..=17 => Some(SortField::User),
-        18..=23 => Some(SortField::Cpu),
-        24..=37 => Some(SortField::Mem),
-        38..=46 => Some(SortField::Io),
-        47..=54 => Some(SortField::Gpu),
-        55..=62 => Some(SortField::Time),
-        63..=64 => None,
-        _ => Some(SortField::Name),
+/// Walks the configured columns, mirroring the widths (plus the one-cell
+/// column spacing) that `ui::render_procs` hands to the table.
+pub fn header_sort_at(columns: &[ProcColumn], rel_x: u16) -> Option<SortField> {
+    let mut x = 0u16;
+    for col in columns {
+        match col.width() {
+            // The flexible column runs to the right edge of the table.
+            None => return col.sort_field(),
+            Some(w) => {
+                x = x.saturating_add(w).saturating_add(1); // + column spacing
+                if rel_x < x {
+                    return col.sort_field();
+                }
+            }
+        }
     }
+    None
 }
 
 #[cfg(test)]
@@ -986,10 +1118,11 @@ mod tests {
 
     #[test]
     fn header_click_map_matches_column_layout() {
-        assert_eq!(header_sort_at(0), Some(SortField::Pid));
-        assert_eq!(header_sort_at(18), Some(SortField::Cpu));
-        assert_eq!(header_sort_at(40), Some(SortField::Io));
-        assert_eq!(header_sort_at(63), None);
-        assert_eq!(header_sort_at(120), Some(SortField::Name));
+        let cols = DEFAULT_COLUMNS;
+        assert_eq!(header_sort_at(cols, 0), Some(SortField::Pid));
+        assert_eq!(header_sort_at(cols, 18), Some(SortField::Cpu));
+        assert_eq!(header_sort_at(cols, 40), Some(SortField::Io));
+        assert_eq!(header_sort_at(cols, 63), None);
+        assert_eq!(header_sort_at(cols, 120), Some(SortField::Name));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::alerts::AlertConfig;
-use crate::app::LayoutPreset;
+use crate::app::{LayoutPreset, ProcColumn, DEFAULT_COLUMNS};
+use crate::keys::{Action, KeyMap};
 use crate::theme;
 
 /// User-tunable settings.
@@ -19,7 +20,7 @@ use crate::theme;
 pub struct Config {
     /// Refresh interval in milliseconds.
     pub tick_ms: u64,
-    /// Index into [`theme::THEMES`].
+    /// Index into [`theme::themes()`].
     pub theme_idx: usize,
     /// Show the process tree by default.
     pub tree: bool,
@@ -27,6 +28,13 @@ pub struct Config {
     pub per_core: bool,
     /// Body layout preset.
     pub layout: LayoutPreset,
+    /// Process-table columns, in display order.
+    pub columns: Vec<ProcColumn>,
+    /// Key → action bindings.
+    pub keys: KeyMap,
+    /// Warnings collected while parsing (bad bindings and the like), reported
+    /// once at startup. Never persisted.
+    pub warnings: Vec<String>,
     /// Alert thresholds (VRAM spill, KV-cache saturation, queue backlog).
     pub alerts: AlertConfig,
 }
@@ -39,6 +47,9 @@ impl Default for Config {
             tree: false,
             per_core: true,
             layout: LayoutPreset::Full,
+            columns: DEFAULT_COLUMNS.to_vec(),
+            keys: KeyMap::default(),
+            warnings: Vec::new(),
             alerts: AlertConfig::default(),
         }
     }
@@ -98,6 +109,14 @@ impl Config {
                 "tree" => cfg.tree = parse_bool(value).unwrap_or(cfg.tree),
                 "per_core" => cfg.per_core = parse_bool(value).unwrap_or(cfg.per_core),
                 "layout" => cfg.layout = LayoutPreset::from_name(value).unwrap_or(cfg.layout),
+                "columns" => {
+                    let cols: Vec<ProcColumn> =
+                        value.split(',').filter_map(ProcColumn::from_name).collect();
+                    // An all-unknown list would leave an unusable table.
+                    if !cols.is_empty() {
+                        cfg.columns = cols;
+                    }
+                }
                 "alert_vram_pct" => {
                     if let Ok(v) = value.parse::<f32>() {
                         cfg.alerts.vram_spill_pct = v.clamp(1.0, 100.0);
@@ -113,7 +132,11 @@ impl Config {
                         cfg.alerts.queue_high = v.max(1.0);
                     }
                 }
-                _ => {}
+                _ => {
+                    if let Some(action) = key.strip_prefix("bind_").and_then(Action::from_name) {
+                        cfg.warnings.extend(cfg.keys.bind(action, value));
+                    }
+                }
             }
         }
         cfg
@@ -135,7 +158,7 @@ impl Config {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let theme_name = theme::THEMES
+        let theme_name = theme::themes()
             .get(self.theme_idx)
             .map(|t| t.name)
             .unwrap_or("gruvbox");
@@ -146,6 +169,8 @@ impl Config {
              tree = {}\n\
              per_core = {}\n\
              layout = {}\n\
+             columns = {}\n\
+             # Rebind keys with e.g.  bind_quit = ctrl+x\n\
              alert_vram_pct = {}\n\
              alert_kv_pct = {}\n\
              alert_queue = {}\n",
@@ -154,6 +179,11 @@ impl Config {
             self.tree,
             self.per_core,
             self.layout.label(),
+            self.columns
+                .iter()
+                .map(|c| c.name())
+                .collect::<Vec<_>>()
+                .join(","),
             self.alerts.vram_spill_pct,
             self.alerts.kv_high_pct,
             self.alerts.queue_high
@@ -178,7 +208,7 @@ mod tests {
     fn defaults_are_sane() {
         let c = Config::default();
         assert!(c.tick_ms >= 100);
-        assert!(c.theme_idx < theme::THEMES.len());
+        assert!(c.theme_idx < theme::themes().len());
     }
 
     #[test]
@@ -203,6 +233,44 @@ mod tests {
         assert_eq!(cfg.alerts.vram_spill_pct, 100.0);
         assert_eq!(cfg.alerts.kv_high_pct, 1.0);
         assert_eq!(cfg.alerts.queue_high, AlertConfig::default().queue_high);
+    }
+
+    #[test]
+    fn parses_and_ignores_column_lists() {
+        let cfg = Config::parse("columns = pid, cmd, cpu\n");
+        assert_eq!(
+            cfg.columns,
+            vec![ProcColumn::Pid, ProcColumn::Command, ProcColumn::Cpu]
+        );
+        // Unknown names are dropped; an entirely unknown list keeps the default.
+        assert_eq!(
+            Config::parse("columns = pid, nope\n").columns,
+            vec![ProcColumn::Pid]
+        );
+        assert_eq!(
+            Config::parse("columns = nope\n").columns,
+            DEFAULT_COLUMNS.to_vec()
+        );
+    }
+
+    #[test]
+    fn parses_key_bindings_and_warns_on_bad_ones() {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let cfg = Config::parse("bind_quit = ctrl+x\nbind_tree = nonsense\nbind_nope = z\n");
+        assert_eq!(
+            cfg.keys
+                .action(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL)),
+            Some(Action::Quit)
+        );
+        // The unusable spec warns and leaves the default binding in place.
+        assert!(cfg.warnings.iter().any(|w| w.contains("bind_tree")));
+        assert_eq!(
+            cfg.keys
+                .action(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE)),
+            Some(Action::Tree)
+        );
+        // An unknown action name is ignored silently, like any unknown key.
+        assert_eq!(cfg.warnings.len(), 2);
     }
 
     #[test]

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::json::{self, Json};
-use crate::theme::{Theme, THEMES};
+use crate::theme::{self, Theme};
 
 /// One inference server as reported by a host.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -250,14 +250,14 @@ impl FleetApp {
             monitor,
             hosts,
             selected: 0,
-            theme_idx: theme_idx.min(THEMES.len() - 1),
+            theme_idx: theme_idx.min(theme::themes().len() - 1),
             tick: Duration::from_millis(1000),
             should_quit: false,
         }
     }
 
     pub fn theme(&self) -> &'static Theme {
-        &THEMES[self.theme_idx]
+        &theme::themes()[self.theme_idx]
     }
 
     pub fn on_tick(&mut self) {
@@ -306,10 +306,11 @@ impl FleetApp {
             KeyCode::Home | KeyCode::Char('g') => self.selected = 0,
             KeyCode::End | KeyCode::Char('G') => self.selected = self.hosts.len().saturating_sub(1),
             KeyCode::Char('p') => {
-                self.theme_idx = (self.theme_idx + 1) % THEMES.len();
+                self.theme_idx = (self.theme_idx + 1) % theme::themes().len();
             }
             KeyCode::Char('P') => {
-                self.theme_idx = (self.theme_idx + THEMES.len() - 1) % THEMES.len();
+                self.theme_idx =
+                    (self.theme_idx + theme::themes().len() - 1) % theme::themes().len();
             }
             _ => {}
         }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,351 @@
+//! Rebindable key actions.
+//!
+//! Every main-view action is looked up through a [`KeyMap`] instead of matching
+//! a hardcoded [`KeyCode`], so users can remap keys from the config file with
+//! `bind_<action> = <key>[, <key>...]` lines. Modal input (the filter prompt,
+//! the signal/renice menus, `Esc`, `Ctrl-C`) stays fixed — remapping the keys
+//! that dismiss a prompt would be a way to lock yourself in.
+
+use std::collections::HashMap;
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// A rebindable action.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Action {
+    Quit,
+    Help,
+    Pause,
+    Detail,
+    Up,
+    Down,
+    PageUp,
+    PageDown,
+    First,
+    Last,
+    SortNext,
+    SortInvert,
+    Tree,
+    PerCore,
+    Layout,
+    Connections,
+    Ai,
+    ThemeNext,
+    ThemePrev,
+    TickUp,
+    TickDown,
+    Filter,
+    Kill,
+    Renice,
+    SigTerm,
+    SigKill,
+}
+
+impl Action {
+    /// Config name, used as the `bind_<name>` suffix.
+    pub fn name(self) -> &'static str {
+        match self {
+            Action::Quit => "quit",
+            Action::Help => "help",
+            Action::Pause => "pause",
+            Action::Detail => "detail",
+            Action::Up => "up",
+            Action::Down => "down",
+            Action::PageUp => "page_up",
+            Action::PageDown => "page_down",
+            Action::First => "first",
+            Action::Last => "last",
+            Action::SortNext => "sort_next",
+            Action::SortInvert => "sort_invert",
+            Action::Tree => "tree",
+            Action::PerCore => "per_core",
+            Action::Layout => "layout",
+            Action::Connections => "connections",
+            Action::Ai => "ai",
+            Action::ThemeNext => "theme_next",
+            Action::ThemePrev => "theme_prev",
+            Action::TickUp => "tick_up",
+            Action::TickDown => "tick_down",
+            Action::Filter => "filter",
+            Action::Kill => "kill",
+            Action::Renice => "renice",
+            Action::SigTerm => "sigterm",
+            Action::SigKill => "sigkill",
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        ALL.iter()
+            .copied()
+            .find(|a| a.name() == name.trim().to_ascii_lowercase())
+    }
+}
+
+/// Every action, for lookup and for the `bind_*` config keys.
+pub const ALL: &[Action] = &[
+    Action::Quit,
+    Action::Help,
+    Action::Pause,
+    Action::Detail,
+    Action::Up,
+    Action::Down,
+    Action::PageUp,
+    Action::PageDown,
+    Action::First,
+    Action::Last,
+    Action::SortNext,
+    Action::SortInvert,
+    Action::Tree,
+    Action::PerCore,
+    Action::Layout,
+    Action::Connections,
+    Action::Ai,
+    Action::ThemeNext,
+    Action::ThemePrev,
+    Action::TickUp,
+    Action::TickDown,
+    Action::Filter,
+    Action::Kill,
+    Action::Renice,
+    Action::SigTerm,
+    Action::SigKill,
+];
+
+/// A key plus the modifiers that matter for binding (only Ctrl and Alt —
+/// Shift is already carried by the character itself).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct KeyPress {
+    pub code: KeyCode,
+    pub ctrl: bool,
+    pub alt: bool,
+}
+
+impl KeyPress {
+    pub fn from_event(ev: KeyEvent) -> Self {
+        Self {
+            code: ev.code,
+            ctrl: ev.modifiers.contains(KeyModifiers::CONTROL),
+            alt: ev.modifiers.contains(KeyModifiers::ALT),
+        }
+    }
+
+    /// Parse a spec like `q`, `space`, `pgdn`, `f9` or `ctrl+r`.
+    pub fn parse(spec: &str) -> Option<Self> {
+        let spec = spec.trim();
+        if spec.is_empty() {
+            return None;
+        }
+        let (mut ctrl, mut alt) = (false, false);
+        let mut rest = spec;
+        loop {
+            let lower = rest.to_ascii_lowercase();
+            if let Some(r) = lower.strip_prefix("ctrl+").or(lower.strip_prefix("c-")) {
+                ctrl = true;
+                rest = &rest[rest.len() - r.len()..];
+            } else if let Some(r) = lower.strip_prefix("alt+").or(lower.strip_prefix("m-")) {
+                alt = true;
+                rest = &rest[rest.len() - r.len()..];
+            } else {
+                break;
+            }
+        }
+        // Single characters stay case-sensitive: `P` is a distinct binding
+        // from `p`. Everything else is a case-insensitive key name.
+        let code = if rest.chars().count() == 1 {
+            KeyCode::Char(rest.chars().next().unwrap())
+        } else {
+            match rest.to_ascii_lowercase().as_str() {
+                "up" => KeyCode::Up,
+                "down" => KeyCode::Down,
+                "left" => KeyCode::Left,
+                "right" => KeyCode::Right,
+                "pgup" | "pageup" => KeyCode::PageUp,
+                "pgdn" | "pagedown" => KeyCode::PageDown,
+                "home" => KeyCode::Home,
+                "end" => KeyCode::End,
+                "enter" | "return" => KeyCode::Enter,
+                "tab" => KeyCode::Tab,
+                "space" => KeyCode::Char(' '),
+                "backspace" => KeyCode::Backspace,
+                "delete" | "del" => KeyCode::Delete,
+                "insert" | "ins" => KeyCode::Insert,
+                "esc" | "escape" => KeyCode::Esc,
+                other => {
+                    let n = other.strip_prefix('f')?.parse::<u8>().ok()?;
+                    if (1..=12).contains(&n) {
+                        KeyCode::F(n)
+                    } else {
+                        return None;
+                    }
+                }
+            }
+        };
+        Some(KeyPress { code, ctrl, alt })
+    }
+}
+
+/// Key → action lookup table.
+#[derive(Clone, Debug)]
+pub struct KeyMap {
+    map: HashMap<KeyPress, Action>,
+}
+
+/// The built-in bindings, as config specs — also the documentation of what a
+/// `bind_*` line replaces.
+pub const DEFAULT_BINDINGS: &[(Action, &str)] = &[
+    (Action::Quit, "q"),
+    (Action::Help, "?, f1"),
+    (Action::Pause, "space"),
+    (Action::Detail, "enter"),
+    (Action::Up, "up, k"),
+    (Action::Down, "down, j"),
+    (Action::PageUp, "pgup"),
+    (Action::PageDown, "pgdn"),
+    (Action::First, "home, g"),
+    (Action::Last, "end, G"),
+    (Action::SortNext, "s"),
+    (Action::SortInvert, "i"),
+    (Action::Tree, "t"),
+    (Action::PerCore, "e"),
+    (Action::Layout, "L"),
+    (Action::Connections, "n"),
+    (Action::Ai, "a"),
+    (Action::ThemeNext, "p"),
+    (Action::ThemePrev, "P"),
+    (Action::TickUp, "+, ="),
+    (Action::TickDown, "-, _"),
+    (Action::Filter, "/"),
+    (Action::Kill, "K, f9"),
+    (Action::Renice, "r"),
+    (Action::SigTerm, "delete"),
+    (Action::SigKill, "x"),
+];
+
+impl Default for KeyMap {
+    fn default() -> Self {
+        let mut km = KeyMap {
+            map: HashMap::new(),
+        };
+        for (action, spec) in DEFAULT_BINDINGS {
+            km.bind(*action, spec);
+        }
+        km
+    }
+}
+
+impl KeyMap {
+    /// Resolve a key event to an action.
+    pub fn action(&self, ev: KeyEvent) -> Option<Action> {
+        self.map.get(&KeyPress::from_event(ev)).copied()
+    }
+
+    /// Rebind `action` to a comma-separated key list, replacing whatever it was
+    /// bound to before.
+    ///
+    /// Returns one warning per key spec that could not be parsed. A key already
+    /// used by another action is re-pointed at `action` (last binding wins), so
+    /// swapping two keys never leaves both stuck on the same action.
+    pub fn bind(&mut self, action: Action, spec: &str) -> Vec<String> {
+        let keys: Vec<KeyPress> = spec.split(',').filter_map(KeyPress::parse).collect();
+        let mut warnings: Vec<String> = spec
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && KeyPress::parse(s).is_none())
+            .map(|s| format!("bind_{}: '{s}' is not a known key, ignored", action.name()))
+            .collect();
+        if keys.is_empty() {
+            warnings.push(format!(
+                "bind_{}: no usable key, keeping the default",
+                action.name()
+            ));
+            return warnings;
+        }
+        self.map.retain(|_, a| *a != action);
+        for key in keys {
+            self.map.insert(key, action);
+        }
+        warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn defaults_cover_every_action() {
+        let km = KeyMap::default();
+        for action in ALL {
+            assert!(
+                km.map.values().any(|a| a == action),
+                "{} has no default binding",
+                action.name()
+            );
+        }
+        assert_eq!(km.action(ev(KeyCode::Char('q'))), Some(Action::Quit));
+        assert_eq!(km.action(ev(KeyCode::Char(' '))), Some(Action::Pause));
+        assert_eq!(km.action(ev(KeyCode::F(9))), Some(Action::Kill));
+    }
+
+    #[test]
+    fn key_spec_parsing() {
+        assert_eq!(KeyPress::parse("k").unwrap().code, KeyCode::Char('k'));
+        assert_eq!(KeyPress::parse("PgDn").unwrap().code, KeyCode::PageDown);
+        assert_eq!(KeyPress::parse("f12").unwrap().code, KeyCode::F(12));
+        assert_eq!(KeyPress::parse("space").unwrap().code, KeyCode::Char(' '));
+        let c = KeyPress::parse("ctrl+r").unwrap();
+        assert_eq!((c.code, c.ctrl), (KeyCode::Char('r'), true));
+        // Case matters for single characters.
+        assert_ne!(KeyPress::parse("p"), KeyPress::parse("P"));
+        assert_eq!(KeyPress::parse("f42"), None);
+        assert_eq!(KeyPress::parse("nonsense"), None);
+        assert_eq!(KeyPress::parse("  "), None);
+    }
+
+    #[test]
+    fn rebinding_replaces_the_old_key() {
+        let mut km = KeyMap::default();
+        assert!(km.bind(Action::Quit, "ctrl+x").is_empty());
+        assert_eq!(km.action(ev(KeyCode::Char('q'))), None);
+        assert_eq!(
+            km.action(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL)),
+            Some(Action::Quit)
+        );
+    }
+
+    #[test]
+    fn duplicate_binding_is_last_wins() {
+        let mut km = KeyMap::default();
+        // `t` already toggles the tree; pointing it at the AI view must not
+        // leave it doing both.
+        km.bind(Action::Ai, "t");
+        assert_eq!(km.action(ev(KeyCode::Char('t'))), Some(Action::Ai));
+        assert_eq!(km.action(ev(KeyCode::Char('a'))), None);
+    }
+
+    #[test]
+    fn unknown_keys_warn_and_keep_the_default() {
+        let mut km = KeyMap::default();
+        let w = km.bind(Action::Tree, "nonsense");
+        assert_eq!(w.len(), 2, "one per bad key plus the fallback note");
+        assert!(w[0].contains("not a known key"));
+        // The default binding survives an unusable spec.
+        assert_eq!(km.action(ev(KeyCode::Char('t'))), Some(Action::Tree));
+
+        let w = km.bind(Action::Tree, "T, bogus");
+        assert_eq!(w.len(), 1);
+        assert_eq!(km.action(ev(KeyCode::Char('T'))), Some(Action::Tree));
+    }
+
+    #[test]
+    fn action_names_round_trip() {
+        for a in ALL {
+            assert_eq!(Action::from_name(a.name()), Some(*a));
+        }
+        assert_eq!(Action::from_name("nope"), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod export;
 pub mod fleet;
 pub mod history;
 pub mod json;
+pub mod keys;
 pub mod metrics;
 pub mod serve;
 pub mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ USAGE:
 
 OPTIONS:
     -t, --tick <MS>      Refresh interval in milliseconds (100-60000)
-        --theme <NAME>   Color theme (gruvbox, nord, dracula, tokyonight, matrix, cyberpunk, paper)
+        --theme <NAME>   Color theme (gruvbox, nord, dracula, tokyonight, matrix, cyberpunk,
+                         paper, or a user theme from ~/.config/toptop/themes/<name>.conf)
         --tree           Start in process-tree view
         --no-tree        Start in flat process view
         --ai             Open the AI / local-LLM GPU view on launch
@@ -237,11 +238,20 @@ fn arg_error(msg: &str) -> ! {
 fn main() -> Result<()> {
     let argv: Vec<String> = std::env::args().skip(1).collect();
 
+    // User themes must be registered before the config file is read — it
+    // resolves `theme = <name>` against the registry.
+    for warning in theme::init_user_themes(theme::user_theme_dir().as_deref()) {
+        eprintln!("toptop: {warning}");
+    }
+
     let config_path = config_path_arg(&argv).unwrap_or_else(|e| arg_error(&e));
     let cfg = match &config_path {
         Some(path) => Config::load_path(path),
         None => Config::load(),
     };
+    for warning in &cfg.warnings {
+        eprintln!("toptop: {warning}");
+    }
     let opts = parse_args(&argv, cfg).unwrap_or_else(|e| arg_error(&e));
 
     match opts.action {
@@ -254,8 +264,13 @@ fn main() -> Result<()> {
             return Ok(());
         }
         Action::ListThemes => {
-            for t in theme::THEMES {
-                println!("{}", t.name);
+            let builtin = theme::BUILTINS.len();
+            for (i, t) in theme::themes().iter().enumerate() {
+                if i < builtin {
+                    println!("{}", t.name);
+                } else {
+                    println!("{}  (user)", t.name);
+                }
             }
             return Ok(());
         }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,6 +5,10 @@
 //! on load (typically green → yellow → red). Colors are emitted as true RGB so
 //! the gradients are smooth on any 24-bit-capable terminal.
 
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
 use ratatui::style::Color;
 
 /// An RGB triple used for interpolation before being handed to ratatui.
@@ -136,8 +140,9 @@ static GRAD_PAPER: [Rgb; 4] = [
     rgb(183, 28, 28), // red 900
 ];
 
-/// All themes, in cycle order.
-pub static THEMES: &[Theme] = &[
+/// The compile-time themes, in cycle order. User themes loaded from
+/// `themes/*.conf` are appended to these by [`init_user_themes`].
+pub static BUILTINS: &[Theme] = &[
     Theme {
         name: "gruvbox",
         fg: rgb(235, 219, 178),
@@ -267,11 +272,160 @@ pub static THEMES: &[Theme] = &[
     },
 ];
 
+// ── Theme registry (built-ins + user themes) ─────────────────────────────────
+
+/// The active theme list: built-ins first, then any user themes loaded from
+/// disk. Populated once by [`init_user_themes`]; falls back to the built-ins
+/// when nothing was loaded (tests, `--export`, library use).
+static REGISTRY: OnceLock<Vec<Theme>> = OnceLock::new();
+
+/// All themes available at runtime, in cycle order.
+pub fn themes() -> &'static [Theme] {
+    REGISTRY.get_or_init(|| BUILTINS.to_vec())
+}
+
 /// Look up a theme index by name (case-insensitive). Returns `None` if unknown.
 pub fn index_by_name(name: &str) -> Option<usize> {
-    THEMES
+    themes()
         .iter()
         .position(|t| t.name.eq_ignore_ascii_case(name))
+}
+
+/// The user theme directory, honoring `XDG_CONFIG_HOME`.
+pub fn user_theme_dir() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+    Some(base.join("toptop").join("themes"))
+}
+
+/// Load `*.conf` theme files from `dir` and append them to the registry.
+///
+/// Call once, before the config file is read (it resolves `theme = <name>`).
+/// Returns one warning line per file that could not be parsed; a broken file is
+/// skipped, never fatal. Later calls are no-ops.
+pub fn init_user_themes(dir: Option<&Path>) -> Vec<String> {
+    let mut list = BUILTINS.to_vec();
+    let mut warnings = Vec::new();
+    if let Some(dir) = dir {
+        let mut files: Vec<PathBuf> = fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|e| e == "conf"))
+            .collect();
+        // Directory order is unspecified; sort so the cycle order is stable.
+        files.sort();
+        for path in files {
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Ok(contents) = fs::read_to_string(&path) else {
+                warnings.push(format!("theme {}: unreadable, ignored", path.display()));
+                continue;
+            };
+            match parse_theme(stem, &contents) {
+                Ok(theme) => {
+                    // A user theme may not shadow a built-in name, or `--theme`
+                    // would become ambiguous.
+                    if list.iter().any(|t| t.name.eq_ignore_ascii_case(theme.name)) {
+                        warnings.push(format!("theme '{stem}': name already taken, ignored"));
+                    } else {
+                        list.push(theme);
+                    }
+                }
+                Err(e) => warnings.push(format!("theme '{stem}': {e}, ignored")),
+            }
+        }
+    }
+    let _ = REGISTRY.set(list);
+    warnings
+}
+
+/// Build a theme from `key = #rrggbb` lines.
+///
+/// `base = <built-in>` picks the theme every unset key falls back to (default
+/// `gruvbox`), so a file only has to state what it changes. `gradient` takes a
+/// comma-separated list of stops.
+pub fn parse_theme(name: &str, contents: &str) -> Result<Theme, String> {
+    let mut base_name = "gruvbox".to_string();
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let (key, value) = (key.trim().to_ascii_lowercase(), value.trim().to_string());
+        if key == "base" {
+            base_name = value;
+        } else {
+            pairs.push((key, value));
+        }
+    }
+
+    let base = BUILTINS
+        .iter()
+        .find(|t| t.name.eq_ignore_ascii_case(&base_name))
+        .ok_or_else(|| format!("unknown base theme '{base_name}'"))?;
+
+    let mut theme = base.clone();
+    theme.name = Box::leak(name.to_ascii_lowercase().into_boxed_str());
+
+    for (key, value) in pairs {
+        match key.as_str() {
+            "gradient" => {
+                let stops = value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(parse_hex)
+                    .collect::<Result<Vec<Rgb>, String>>()?;
+                if stops.is_empty() {
+                    return Err("gradient needs at least one color".to_string());
+                }
+                theme.gradient = Box::leak(stops.into_boxed_slice());
+            }
+            // `bg = none` keeps the terminal's own background.
+            "bg" if value.eq_ignore_ascii_case("none") => theme.bg = None,
+            "bg" => theme.bg = Some(parse_hex(&value)?),
+            _ => {
+                let slot = match key.as_str() {
+                    "fg" => &mut theme.fg,
+                    "dim" => &mut theme.dim,
+                    "accent" => &mut theme.accent,
+                    "accent2" => &mut theme.accent2,
+                    "border" => &mut theme.border,
+                    "border_focus" => &mut theme.border_focus,
+                    "mem" => &mut theme.mem,
+                    "swap" => &mut theme.swap,
+                    "net_down" => &mut theme.net_down,
+                    "net_up" => &mut theme.net_up,
+                    "disk_read" => &mut theme.disk_read,
+                    "disk_write" => &mut theme.disk_write,
+                    "selection" => &mut theme.selection,
+                    // Unknown keys keep the base value rather than failing the
+                    // whole file — forward compatible with newer key sets.
+                    _ => continue,
+                };
+                *slot = parse_hex(&value)?;
+            }
+        }
+    }
+    Ok(theme)
+}
+
+/// Parse `#rrggbb` (the leading `#` optional) into an [`Rgb`].
+fn parse_hex(value: &str) -> Result<Rgb, String> {
+    let hex = value.strip_prefix('#').unwrap_or(value);
+    if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!("'{value}' is not a #rrggbb color"));
+    }
+    let byte = |i: usize| u8::from_str_radix(&hex[i..i + 2], 16).unwrap();
+    Ok(Rgb(byte(0), byte(2), byte(4)))
 }
 
 #[cfg(test)]
@@ -289,7 +443,7 @@ mod tests {
 
     #[test]
     fn gradient_bounds() {
-        let theme = &THEMES[0];
+        let theme = &themes()[0];
         assert_eq!(theme.grad_rgb(0.0), theme.gradient[0]);
         assert_eq!(
             theme.grad_rgb(1.0),
@@ -301,11 +455,62 @@ mod tests {
     }
 
     #[test]
+    fn hex_parsing() {
+        assert_eq!(parse_hex("#ff8000"), Ok(Rgb(255, 128, 0)));
+        assert_eq!(parse_hex("FF8000"), Ok(Rgb(255, 128, 0)));
+        assert!(parse_hex("#fff").is_err());
+        assert!(parse_hex("#gggggg").is_err());
+        assert!(parse_hex("").is_err());
+    }
+
+    #[test]
+    fn user_theme_overrides_base_and_keeps_the_rest() {
+        let t = parse_theme(
+            "Midnight",
+            "# my theme\nbase = nord\naccent = #ff0000\nbg = none\nunknown_key = #123456\n",
+        )
+        .expect("valid theme");
+        assert_eq!(t.name, "midnight");
+        assert_eq!(t.accent, Rgb(255, 0, 0));
+        assert_eq!(t.bg, None);
+        // Untouched keys keep the base theme's values.
+        let nord = BUILTINS.iter().find(|b| b.name == "nord").unwrap();
+        assert_eq!(t.fg, nord.fg);
+        assert_eq!(t.gradient, nord.gradient);
+    }
+
+    #[test]
+    fn user_theme_gradient_and_failures() {
+        let t = parse_theme("g", "gradient = #000000, #ffffff\n").unwrap();
+        assert_eq!(t.gradient, &[Rgb(0, 0, 0), Rgb(255, 255, 255)]);
+
+        assert!(parse_theme("b", "base = nope\n").is_err());
+        assert!(parse_theme("b", "accent = purple\n").is_err());
+        assert!(parse_theme("b", "gradient =\n").is_err());
+    }
+
+    #[test]
+    fn broken_theme_files_are_skipped_with_a_warning() {
+        let dir = std::env::temp_dir().join(format!("toptop-themes-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("broken.conf"), "accent = not-a-color\n").unwrap();
+        fs::write(dir.join("gruvbox.conf"), "accent = #ffffff\n").unwrap();
+        fs::write(dir.join("notes.txt"), "ignored\n").unwrap();
+        let warnings = init_user_themes(Some(&dir));
+        fs::remove_dir_all(&dir).ok();
+
+        assert!(warnings.iter().any(|w| w.contains("broken")));
+        assert!(warnings.iter().any(|w| w.contains("name already taken")));
+        // A built-in must not be replaced by a same-named user file.
+        assert_eq!(index_by_name("gruvbox"), Some(0));
+    }
+
+    #[test]
     fn all_themes_resolve() {
-        for t in THEMES {
+        for t in themes() {
             assert_eq!(
                 index_by_name(t.name),
-                Some(THEMES.iter().position(|x| x.name == t.name).unwrap())
+                Some(themes().iter().position(|x| x.name == t.name).unwrap())
             );
         }
         assert_eq!(index_by_name("nope"), None);

--- a/src/ui/graph.rs
+++ b/src/ui/graph.rs
@@ -207,7 +207,7 @@ pub fn meter_spans(pct: f32, width: usize, theme: &Theme) -> Vec<Span<'static>> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::theme::THEMES;
+    use crate::theme::BUILTINS as THEMES;
 
     #[test]
     fn graph_dimensions() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,7 +9,8 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table};
 use ratatui::Frame;
 
-use crate::app::App;
+use crate::app::{App, ProcColumn};
+use crate::metrics::ProcInfo;
 use crate::theme::Theme;
 use crate::util::{
     clamp_pct, compact_duration, human_bytes, human_duration, human_rate, short_bytes, truncate,
@@ -700,18 +701,13 @@ fn render_procs(f: &mut Frame, area: Rect, app: &mut App) {
         height: rows_cap as u16,
     };
 
-    let header = Row::new(vec![
-        Cell::from("PID"),
-        Cell::from("USER"),
-        Cell::from("CPU%"),
-        Cell::from("MEM%"),
-        Cell::from("MEM"),
-        Cell::from("DISK"),
-        Cell::from("VRAM"),
-        Cell::from("TIME"),
-        Cell::from("S"),
-        Cell::from("COMMAND"),
-    ])
+    let columns = app.columns.clone();
+    let header = Row::new(
+        columns
+            .iter()
+            .map(|c| Cell::from(c.header()))
+            .collect::<Vec<_>>(),
+    )
     .style(
         Style::default()
             .fg(theme.accent.color())
@@ -728,41 +724,12 @@ fn render_procs(f: &mut Frame, area: Rect, app: &mut App) {
             p.cmd.clone()
         };
         let cpu = clamp_pct(p.cpu);
-        let row = Row::new(vec![
-            Cell::from(format!("{:>7}", p.pid)),
-            Cell::from(truncate(&p.user, 9)),
-            Cell::from(Span::styled(
-                format!("{:>5.1}", p.cpu.min(999.0)),
-                Style::default().fg(theme.grad(cpu / 100.0)),
-            )),
-            Cell::from(Span::styled(
-                format!("{:>5.1}", p.mem_pct),
-                Style::default().fg(theme.grad((p.mem_pct / 100.0).clamp(0.0, 1.0))),
-            )),
-            Cell::from(short_bytes(p.mem_bytes)),
-            Cell::from({
-                let io = p.io_read_rate + p.io_write_rate;
-                if io >= 1.0 {
-                    Span::styled(
-                        format!("{}/s", short_bytes(io as u64)),
-                        Style::default().fg(theme.disk_write.color()),
-                    )
-                } else {
-                    Span::styled("·", dim(theme))
-                }
-            }),
-            Cell::from(if p.gpu_mem > 0 {
-                Span::styled(
-                    short_bytes(p.gpu_mem),
-                    Style::default().fg(theme.accent2.color()),
-                )
-            } else {
-                Span::styled("·", dim(theme))
-            }),
-            Cell::from(compact_duration(p.run_time)),
-            Cell::from(p.status.to_string()),
-            Cell::from(cmd),
-        ]);
+        let row = Row::new(
+            columns
+                .iter()
+                .map(|c| proc_cell(*c, p, &cmd, cpu, theme))
+                .collect::<Vec<_>>(),
+        );
         let row = if selected {
             row.style(
                 Style::default()
@@ -776,20 +743,55 @@ fn render_procs(f: &mut Frame, area: Rect, app: &mut App) {
         rows.push(row);
     }
 
-    let widths = [
-        Constraint::Length(7),
-        Constraint::Length(9),
-        Constraint::Length(5),
-        Constraint::Length(5),
-        Constraint::Length(7),
-        Constraint::Length(8),
-        Constraint::Length(7),
-        Constraint::Length(7),
-        Constraint::Length(1),
-        Constraint::Min(10),
-    ];
+    let widths: Vec<Constraint> = columns
+        .iter()
+        .map(|c| match c.width() {
+            Some(w) => Constraint::Length(w),
+            None => Constraint::Min(10),
+        })
+        .collect();
     let table = Table::new(rows, widths).header(header).column_spacing(1);
     f.render_widget(table, inner);
+}
+
+/// Render one process-table cell. `cmd` is the (possibly tree-indented) command
+/// and `cpu` the clamped CPU percentage, both computed once per row.
+fn proc_cell<'a>(col: ProcColumn, p: &'a ProcInfo, cmd: &str, cpu: f32, theme: &Theme) -> Cell<'a> {
+    match col {
+        ProcColumn::Pid => Cell::from(format!("{:>7}", p.pid)),
+        ProcColumn::User => Cell::from(truncate(&p.user, 9)),
+        ProcColumn::Cpu => Cell::from(Span::styled(
+            format!("{:>5.1}", p.cpu.min(999.0)),
+            Style::default().fg(theme.grad(cpu / 100.0)),
+        )),
+        ProcColumn::MemPct => Cell::from(Span::styled(
+            format!("{:>5.1}", p.mem_pct),
+            Style::default().fg(theme.grad((p.mem_pct / 100.0).clamp(0.0, 1.0))),
+        )),
+        ProcColumn::Mem => Cell::from(short_bytes(p.mem_bytes)),
+        ProcColumn::Disk => Cell::from({
+            let io = p.io_read_rate + p.io_write_rate;
+            if io >= 1.0 {
+                Span::styled(
+                    format!("{}/s", short_bytes(io as u64)),
+                    Style::default().fg(theme.disk_write.color()),
+                )
+            } else {
+                Span::styled("·", dim(theme))
+            }
+        }),
+        ProcColumn::Vram => Cell::from(if p.gpu_mem > 0 {
+            Span::styled(
+                short_bytes(p.gpu_mem),
+                Style::default().fg(theme.accent2.color()),
+            )
+        } else {
+            Span::styled("·", dim(theme))
+        }),
+        ProcColumn::Time => Cell::from(compact_duration(p.run_time)),
+        ProcColumn::State => Cell::from(p.status.to_string()),
+        ProcColumn::Command => Cell::from(cmd.to_string()),
+    }
 }
 
 // ── Footer ───────────────────────────────────────────────────────────────────

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -230,16 +230,22 @@ fn connections_collect_without_panic() {
 
 #[test]
 fn header_sort_mapping() {
-    use toptop::app::{header_sort_at, SortField};
-    assert_eq!(header_sort_at(0), Some(SortField::Pid));
-    assert_eq!(header_sort_at(10), Some(SortField::User));
-    assert_eq!(header_sort_at(20), Some(SortField::Cpu));
-    assert_eq!(header_sort_at(26), Some(SortField::Mem));
-    assert_eq!(header_sort_at(40), Some(SortField::Io));
-    assert_eq!(header_sort_at(50), Some(SortField::Gpu));
-    assert_eq!(header_sort_at(58), Some(SortField::Time));
-    assert_eq!(header_sort_at(63), None);
-    assert_eq!(header_sort_at(70), Some(SortField::Name));
+    use toptop::app::{header_sort_at, SortField, DEFAULT_COLUMNS as C};
+    assert_eq!(header_sort_at(C, 0), Some(SortField::Pid));
+    assert_eq!(header_sort_at(C, 10), Some(SortField::User));
+    assert_eq!(header_sort_at(C, 20), Some(SortField::Cpu));
+    assert_eq!(header_sort_at(C, 26), Some(SortField::Mem));
+    assert_eq!(header_sort_at(C, 40), Some(SortField::Io));
+    assert_eq!(header_sort_at(C, 50), Some(SortField::Gpu));
+    assert_eq!(header_sort_at(C, 58), Some(SortField::Time));
+    assert_eq!(header_sort_at(C, 63), None);
+    assert_eq!(header_sort_at(C, 70), Some(SortField::Name));
+
+    // A custom column set remaps the ranges: pid(7+1) then command takes the rest.
+    use toptop::app::ProcColumn;
+    let custom = &[ProcColumn::Pid, ProcColumn::Command];
+    assert_eq!(header_sort_at(custom, 0), Some(SortField::Pid));
+    assert_eq!(header_sort_at(custom, 9), Some(SortField::Name));
 }
 
 #[test]
@@ -276,7 +282,7 @@ fn interaction_flow_is_stable() {
     assert!(app.filter.is_empty());
 
     // Cycle through every theme and re-render.
-    for _ in 0..toptop::theme::THEMES.len() + 1 {
+    for _ in 0..toptop::theme::themes().len() + 1 {
         app.on_key(key(KeyCode::Char('p')));
         render_at(&mut app, 120, 40);
     }


### PR DESCRIPTION
Three config-file features that share the same `key = value` plumbing, so they land as one PR.

### User themes (#17)
`$XDG_CONFIG_HOME/toptop/themes/<name>.conf` files are loaded at startup and appended to the built-ins — `--theme`, `--list-themes` (which marks them `(user)`) and the `p` cycle treat them like any other theme.

```ini
# ~/.config/toptop/themes/midnight.conf
base = nord
accent = #ff2e97
bg = none
gradient = #00f0ff, #7b61ff, #ff2e97
```

`base` supplies every unset key, colors are `#rrggbb`, unknown keys are kept (forward compatible). A broken file warns on stderr and is skipped — never fatal.

Internally the `THEMES` static became a `themes()` registry (`BUILTINS` + user themes) behind a `OnceLock`, initialized before the config file is read since that resolves `theme = <name>`.

### Keybindings (#42)
`App::on_key`'s hardcoded `KeyCode` match now resolves through a `KeyMap` (new `src/keys.rs`):

```ini
bind_quit = ctrl+x
bind_up = up, w
```

26 rebindable actions; key names cover characters (case-sensitive), arrows, `pgup`/`pgdn`, `home`/`end`, `enter`, `space`, `delete`, `f1`–`f12`, with `ctrl+`/`alt+` prefixes. Unknown keys warn and keep the default; binding an already-used key moves it (last wins). `Esc` and `Ctrl-C` stay fixed — remapping the way out of an overlay is a footgun.

### Process-table columns (#43)
A `ProcColumn` enum plus a `columns` key drives the header, the row cells and click-to-sort:

```ini
columns = pid, cpu, mem%, vram, command
```

`header_sort_at` now walks the configured widths instead of hardcoded ranges.

### Verification
- `cargo test` — 129 green (was 113), incl. new unit tests for hex/theme parsing, broken-file fallback, key-spec parsing, rebinding, duplicate-key and unknown-key handling, column lists, and a custom-column sort-hit test.
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean.

Closes #17, closes #42, closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for user-defined themes, including inheritance, color overrides, gradients, and fallback warnings.
  * Added customizable process-table columns, ordering, widths, and sorting.
  * Added configurable keybindings with modifier, function-key, and named-key support.
  * Added theme listing for both built-in and user themes.
* **Documentation**
  * Expanded configuration and theme usage documentation.
  * Updated the test-count badge and changelog with the new customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->