### PR TITLE
KV-cache preemption and GPU compute-vs-bandwidth history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **KV-cache preemption surfaced as a critical alert** — when a serving runtime
+  runs out of KV cache it preempts in-flight requests, throwing away work
+  already done and recomputing it later. Throughput collapses while every
+  dashboard still shows a busy, healthy GPU. toptop scrapes vLLM's and
+  TensorRT-LLM's preemption counters, differences them into a rate, shows
+  `⟲ preempt 1.8/s` in the AI view, and alerts at **critical** — above a queue
+  backlog, because a backlog only delays work whereas preemption destroys it.
+  Tunable via `alert_preempt` / `--alert-preempt`, exported as
+  `toptop_inference_preemptions_{total,per_second}`. (#31)
+- **GPU compute-vs-bandwidth history** — per-GPU histories of compute,
+  memory-bandwidth and VRAM utilization, drawn in the AI view as one mirrored
+  braille graph (compute above the midline, bandwidth below). Token generation
+  is bandwidth-bound once the model is resident, so the divergence between the
+  two lines over time is the diagnosis: bandwidth pinned while compute idles
+  means memory-bound, and a faster GPU core will not help. (#32)
+
 - **Inference SLO triad** — TTFT *and* TPOT (time-per-output-token, the
   inter-token latency users feel while a response streams) as p50/p95/p99,
   derived by parsing the runtimes' Prometheus histogram buckets with linear

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-126%20green-success)
+![Tests](https://img.shields.io/badge/tests-132%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 
@@ -133,6 +133,8 @@ sensors, battery, seven themes — all in a single **~1 MB binary with zero runt
 | 🌐 **Network + connections** | per‑interface rx/tx braille graph; a live TCP/UDP table mapping sockets → process (`n`) |
 | 🗄️ **Disk + sensors** | per‑mount usage, read/write I/O graph, temperatures, battery |
 | 📊 **Inference SLO triad** | TTFT and TPOT p50/p95/p99 from vLLM/TGI/TensorRT-LLM/SGLang histograms, plus the prefill-vs-decode phase mix |
+| ⟲ **KV-cache preemption** | The signal no other tool shows: requests thrown away and recomputed because the cache ran out — a critical alert, not a footnote |
+| 📉 **Compute vs bandwidth over time** | A mirrored braille graph per GPU: compute above the line, memory bandwidth below. The divergence *is* the diagnosis |
 | 🎨 **Seven themes & layouts** | `gruvbox` · `nord` · `dracula` · `tokyonight` · `matrix` · `cyberpunk` · `paper` (light terminals); `full`/`cpu`/`process` presets |
 | 🪶 **Tiny & safe** | ~1 MB binary, zero runtime deps, adaptive 250‑col→tiny layout, restores your terminal even on panic |
 
@@ -337,6 +339,8 @@ OPTIONS:
         --alert-vram <PCT>   VRAM % that triggers the spill‑risk alert (default 90)
         --alert-kv <PCT>     KV‑cache % considered saturated (default 95)
         --alert-queue <N>    Queued requests considered a backlog (default 8)
+        --alert-preempt <R>  KV-cache preemptions/sec that trigger a critical alert
+                             (default 0.2 — preemption throws away completed work)
     -h, --help           Show help
     -V, --version        Show version
 ```
@@ -412,6 +416,42 @@ source completions/toptop.bash                    # bash (or copy to /etc/bash_c
 cp completions/_toptop ~/.zfunc/                  # zsh  (ensure ~/.zfunc is on your $fpath)
 cp completions/toptop.fish ~/.config/fish/completions/   # fish
 ```
+
+### KV-cache preemption — the metric nothing else surfaces
+
+When a serving runtime runs out of KV cache, it **preempts** in-flight
+requests: the work already done on them is thrown away and recomputed later.
+Throughput collapses, latency spikes — and every dashboard still shows a busy,
+healthy-looking GPU. `nvidia-smi` cannot see it, and neither can any other
+terminal monitor.
+
+toptop scrapes the counter, differences it into a rate, and treats a sustained
+nonzero rate as **critical** — above a queue backlog, because a backlog only
+delays work while preemption destroys work already done:
+
+```
+  vLLM:8000  Llama-3-8B
+    83.4 tok/s  prefill 1200/s  kv 99%  req 4/12  ⟲ preempt 1.8/s
+```
+
+Tune with `alert_preempt = 0.5` or `--alert-preempt 0.5`; exported as
+`toptop_inference_preemptions_{total,per_second}`.
+
+### Compute vs memory bandwidth, over time
+
+Token generation is memory-bandwidth-bound once the model is resident. toptop
+draws both as one mirrored braille graph per GPU — compute above the midline,
+bandwidth below:
+
+```
+  trend      compute ▲  /  ▼ bandwidth
+             ⢀⣀⣠⣤⣶⣶⣤⣄⣀⡀⢀⣀⣠⣤⣶
+             ⠉⠛⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+```
+
+Bandwidth pinned while compute idles means you are memory-bound and a faster
+GPU core will not help you. That divergence is the whole diagnosis, and it is
+only visible over time.
 
 ### Remote and non-Linux inference servers
 

--- a/examples/preview.rs
+++ b/examples/preview.rs
@@ -70,6 +70,8 @@ fn main() {
                 }),
                 gpu_offload_pct: None,
                 addr: None,
+                preemptions: Some(12.0),
+                preempt_rate: Some(1.2),
             }];
             app.alerts = toptop::alerts::evaluate(&app.collector, &app.alert_cfg);
         }

--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -45,6 +45,11 @@ pub struct AlertConfig {
     pub kv_high_pct: f64,
     /// Number of waiting requests considered a backlog.
     pub queue_high: f64,
+    /// Preemptions per second at or above which the server is thrashing its
+    /// KV cache. The default is deliberately just above zero: a preempted
+    /// request throws away work already done, so a *sustained* nonzero rate is
+    /// always worth knowing about.
+    pub preempt_rate_high: f64,
 }
 
 impl Default for AlertConfig {
@@ -53,6 +58,7 @@ impl Default for AlertConfig {
             vram_spill_pct: 90.0,
             kv_high_pct: 95.0,
             queue_high: 8.0,
+            preempt_rate_high: 0.2,
         }
     }
 }
@@ -98,6 +104,20 @@ pub fn evaluate(c: &Collector, cfg: &AlertConfig) -> Vec<Alert> {
                     key: "queue_backlog",
                     detail: tag.clone(),
                     message: format!("{tag} {waiting:.0} requests queued"),
+                });
+            }
+        }
+        if let Some(rate) = sv.preempt_rate {
+            if rate >= cfg.preempt_rate_high {
+                out.push(Alert {
+                    // Critical: unlike a queue backlog, preemption actively
+                    // destroys work that was already done.
+                    level: Level::Crit,
+                    key: "kv_preemption",
+                    detail: tag.clone(),
+                    message: format!(
+                        "{tag} preempting {rate:.1}/s — KV cache thrashing, work is being recomputed"
+                    ),
                 });
             }
         }
@@ -180,11 +200,37 @@ mod tests {
             vram_spill_pct: 50.0,
             kv_high_pct: 75.0,
             queue_high: 2.0,
+            ..AlertConfig::default()
         };
         let keys: Vec<_> = evaluate(&c, &tight).iter().map(|x| x.key).collect();
         assert!(keys.contains(&"vram_spill"));
         assert!(keys.contains(&"kv_high"));
         assert!(keys.contains(&"queue_backlog"));
+    }
+
+    #[test]
+    fn preemption_is_critical_and_thresholded() {
+        let mut c = Collector::new(16);
+        c.servers = vec![ServerStats {
+            runtime: "vLLM",
+            port: 8000,
+            preempt_rate: Some(1.5),
+            ..Default::default()
+        }];
+        let a = evaluate(&c, &AlertConfig::default());
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].key, "kv_preemption");
+        assert_eq!(
+            a[0].level,
+            Level::Crit,
+            "preemption throws away completed work — it outranks a queue backlog"
+        );
+
+        // A server that has simply never preempted must stay silent.
+        c.servers[0].preempt_rate = Some(0.0);
+        assert!(evaluate(&c, &AlertConfig::default()).is_empty());
+        c.servers[0].preempt_rate = None;
+        assert!(evaluate(&c, &AlertConfig::default()).is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,11 @@ impl Config {
                         cfg.alerts.kv_high_pct = v.clamp(1.0, 100.0);
                     }
                 }
+                "alert_preempt" => {
+                    if let Ok(v) = value.parse::<f64>() {
+                        cfg.alerts.preempt_rate_high = v.max(0.0);
+                    }
+                }
                 "alert_queue" => {
                     if let Ok(v) = value.parse::<f64>() {
                         cfg.alerts.queue_high = v.max(1.0);

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -79,6 +79,14 @@ pub fn apply(c: &mut Collector, t: u64) {
         }),
         gpu_offload_pct: None,
         addr: None,
+        // Once KV saturates, the demo server starts preempting — that is the
+        // whole point of the story it tells.
+        preemptions: Some((t as f64 / 4.0).floor()),
+        preempt_rate: Some(if wave(t, 17.0, 38.0, 97.0, 0.4) > 92.0 {
+            wave(t, 5.0, 0.5, 3.5, 0.1)
+        } else {
+            0.0
+        }),
     }];
 }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -168,7 +168,7 @@ pub fn to_json(c: &Collector, top_procs: usize) -> String {
         .iter()
         .map(|sv| {
             format!(
-                "{{\"runtime\":\"{}\",\"pid\":{},\"port\":{},\"model\":\"{}\",\"gen_tps\":{},\"prompt_tps\":{},\"running\":{},\"waiting\":{},\"kv_pct\":{},\"ttft_ms\":{},\"gpu_offload_pct\":{}}}",
+                "{{\"runtime\":\"{}\",\"pid\":{},\"port\":{},\"model\":\"{}\",\"gen_tps\":{},\"prompt_tps\":{},\"running\":{},\"waiting\":{},\"kv_pct\":{},\"ttft_ms\":{},\"gpu_offload_pct\":{},\"preemptions\":{},\"preempt_rate\":{}}}",
                 esc(sv.runtime),
                 sv.pid,
                 sv.port,
@@ -180,6 +180,8 @@ pub fn to_json(c: &Collector, top_procs: usize) -> String {
                 optnum(sv.kv_pct),
                 optnum(sv.ttft_ms),
                 optnum(sv.gpu_offload_pct),
+                optnum(sv.preemptions),
+                optnum(sv.preempt_rate),
             )
         })
         .collect();
@@ -399,6 +401,14 @@ pub fn to_prometheus(c: &Collector, alert_cfg: &AlertConfig) -> String {
             ),
             ("toptop_inference_ttft_ms", "Time to first token."),
             (
+                "toptop_inference_preemptions_total",
+                "Requests preempted because the KV cache ran out.",
+            ),
+            (
+                "toptop_inference_preemptions_per_second",
+                "Rate of KV-cache preemptions.",
+            ),
+            (
                 "toptop_inference_ttft_p50_ms",
                 "Time to first token, 50th percentile.",
             ),
@@ -443,6 +453,8 @@ pub fn to_prometheus(c: &Collector, alert_cfg: &AlertConfig) -> String {
             s.push_str(&g("requests_running", sv.running));
             s.push_str(&g("requests_waiting", sv.waiting));
             s.push_str(&g("ttft_ms", sv.ttft_ms));
+            s.push_str(&g("preemptions_total", sv.preemptions));
+            s.push_str(&g("preemptions_per_second", sv.preempt_rate));
             s.push_str(&g("ttft_p50_ms", sv.ttft.map(|p| p.p50)));
             s.push_str(&g("ttft_p95_ms", sv.ttft.map(|p| p.p95)));
             s.push_str(&g("ttft_p99_ms", sv.ttft.map(|p| p.p99)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ OPTIONS:
         --alert-vram <PCT>   VRAM % that triggers the spill-risk alert (default 90)
         --alert-kv <PCT>     KV-cache % considered saturated (default 95)
         --alert-queue <N>    Queued requests considered a backlog (default 8)
+        --alert-preempt <R>  KV-cache preemptions/sec that trigger a critical alert
+                             (default 0.2 — preemption throws away completed work)
     -h, --help           Show this help and exit
     -V, --version        Show version and exit
 
@@ -202,6 +204,14 @@ fn parse_args(argv: &[String], cfg: Config) -> Result<Opts, String> {
                     .parse::<f64>()
                     .map_err(|_| "--alert-kv value must be a number")?;
                 opts.cfg.alerts.kv_high_pct = v.clamp(1.0, 100.0);
+            }
+            "--alert-preempt" => {
+                let v = args
+                    .next()
+                    .ok_or("--alert-preempt requires a rate (preemptions/second)")?
+                    .parse::<f64>()
+                    .map_err(|_| "--alert-preempt value must be a number")?;
+                opts.cfg.alerts.preempt_rate_high = v.max(0.0);
             }
             "--alert-queue" => {
                 let v = args

--- a/src/metrics/infer.rs
+++ b/src/metrics/infer.rs
@@ -49,6 +49,14 @@ pub struct ServerStats {
     /// as. Manual targets have no local process, so this replaces the PID as
     /// the label.
     pub addr: Option<String>,
+    /// Cumulative requests preempted because the KV cache ran out. When a
+    /// server preempts, the work already done on that request is thrown away
+    /// and recomputed later — throughput collapses while every dashboard still
+    /// shows a healthy-looking GPU. This is the number that explains it.
+    pub preemptions: Option<f64>,
+    /// Preemptions per second, differenced from the counter. Anything above
+    /// zero is worth acting on.
+    pub preempt_rate: Option<f64>,
 }
 
 /// The p50/p95/p99 triad of a latency distribution, in milliseconds.
@@ -410,6 +418,10 @@ pub fn stats_from_prometheus(text: &str, pid: u32, port: u16) -> Option<ServerSt
         s.running = prom_sum(text, "vllm:num_requests_running");
         s.waiting = prom_sum(text, "vllm:num_requests_waiting");
         s.model = prom_label(text, "vllm:", "model_name").unwrap_or_default();
+        // vLLM renamed this counter across versions; both spellings mean the
+        // same thing, and a server that has never preempted omits it entirely.
+        s.preemptions = prom_sum(text, "vllm:num_preemptions_total")
+            .or_else(|| prom_sum(text, "vllm:num_preemptions"));
         if let (Some(sum), Some(cnt)) = (
             prom_sum(text, "vllm:time_to_first_token_seconds_sum"),
             prom_sum(text, "vllm:time_to_first_token_seconds_count"),
@@ -426,6 +438,7 @@ pub fn stats_from_prometheus(text: &str, pid: u32, port: u16) -> Option<ServerSt
         s.running = prom_sum(text, "trtllm_num_requests_running");
         s.waiting = prom_sum(text, "trtllm_num_requests_waiting");
         s.model = prom_label(text, "trtllm_", "model_name").unwrap_or_default();
+        s.preemptions = prom_sum(text, "trtllm_num_preemptions_total");
         if let (Some(sum), Some(cnt)) = (
             prom_sum(text, "trtllm_time_to_first_token_seconds_sum"),
             prom_sum(text, "trtllm_time_to_first_token_seconds_count"),
@@ -715,6 +728,11 @@ fn apply_counter_rates(
             }
         }
     }
+    // Preemption rate: the counter is cumulative, and it is the *rate* that
+    // says whether the server is thrashing right now.
+    if let Some(preempt) = s.preemptions {
+        s.preempt_rate = counter_rate(prev, (pid, port, "preempt"), preempt, now);
+    }
     if let Some(p) = prom_sum(body, prompt_metric) {
         if let Some(rate) = counter_rate(prev, (pid, port, "prompt"), p, now) {
             if s.prompt_tps.is_none() {
@@ -893,6 +911,59 @@ sglang:time_to_first_token_seconds_bucket{model_name=\"Qwen2-7B\",le=\"+Inf\"} 4
         assert_eq!(s.gen_tps, Some(142.5));
         assert_eq!(s.ttft_ms, Some(300.0));
         assert!(s.ttft.is_some());
+    }
+
+    #[test]
+    fn vllm_preemption_counter_is_parsed() {
+        let text = "\
+vllm:num_requests_running 4
+vllm:gpu_cache_usage_perc 0.99
+vllm:num_preemptions_total{model_name=\"Llama-3-8B\"} 137
+";
+        let s = stats_from_prometheus(text, 1, 8000).expect("vLLM");
+        assert_eq!(s.preemptions, Some(137.0));
+        // The rate needs two scrapes; a single parse has none yet.
+        assert_eq!(s.preempt_rate, None);
+
+        // The older spelling is accepted too.
+        let old = stats_from_prometheus("vllm:num_preemptions 5\n", 1, 8000).expect("vLLM");
+        assert_eq!(old.preemptions, Some(5.0));
+
+        // A server that has never preempted omits the counter entirely, which
+        // must read as "no data", not as zero preemptions.
+        let none = stats_from_prometheus("vllm:num_requests_running 1\n", 1, 8000).unwrap();
+        assert_eq!(none.preemptions, None);
+    }
+
+    #[test]
+    fn preemption_rate_is_differenced_across_scrapes() {
+        let mut prev = HashMap::new();
+        let t0 = Instant::now();
+        let mut s = ServerStats {
+            runtime: "vLLM",
+            preemptions: Some(100.0),
+            ..Default::default()
+        };
+        apply_counter_rates(&mut s, "", &mut prev, 1, 8000, t0);
+        assert_eq!(s.preempt_rate, None, "first scrape has no baseline");
+
+        let mut s2 = ServerStats {
+            runtime: "vLLM",
+            preemptions: Some(104.0),
+            ..Default::default()
+        };
+        apply_counter_rates(&mut s2, "", &mut prev, 1, 8000, t0 + Duration::from_secs(2));
+        assert_eq!(s2.preempt_rate, Some(2.0), "4 preemptions over 2s");
+
+        // A counter that goes backwards (server restarted) must not produce a
+        // negative rate — it produces none until a new baseline exists.
+        let mut s3 = ServerStats {
+            runtime: "vLLM",
+            preemptions: Some(1.0),
+            ..Default::default()
+        };
+        apply_counter_rates(&mut s3, "", &mut prev, 1, 8000, t0 + Duration::from_secs(4));
+        assert_eq!(s3.preempt_rate, None, "a counter reset is not a rate");
     }
 
     #[test]

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -160,6 +160,11 @@ pub struct Collector {
     pub gpus: Vec<Gpu>,
     /// Processes holding GPU memory (NVIDIA only), for the AI/LLM view.
     pub gpu_procs: Vec<GpuProc>,
+    /// Per-GPU compute and memory-bandwidth history, indexed like `gpus`.
+    /// Token generation is bandwidth-bound once the model is resident, so the
+    /// *divergence* between these two lines over time is the single most
+    /// diagnostic picture toptop can draw.
+    pub gpu_history: Vec<GpuHistory>,
     /// Auto-discovered local inference servers (tokens/sec, KV cache, …).
     pub servers: Vec<ServerStats>,
     /// Per-server time series (keyed by pid+port) feeding the AI-view
@@ -167,6 +172,27 @@ pub struct Collector {
     pub server_history: std::collections::HashMap<(u32, u16), ServerHistory>,
     pub battery: Option<Battery>,
     pub uptime: u64,
+}
+
+/// Compute and memory-bandwidth utilization trends for one GPU.
+#[derive(Clone, Debug)]
+pub struct GpuHistory {
+    /// SM/compute utilization %, 0–100.
+    pub compute: History,
+    /// Memory-bandwidth utilization %, 0–100.
+    pub bandwidth: History,
+    /// VRAM used %, 0–100 — the spill story over time.
+    pub vram: History,
+}
+
+impl GpuHistory {
+    fn new(capacity: usize) -> Self {
+        Self {
+            compute: History::new(capacity),
+            bandwidth: History::new(capacity),
+            vram: History::new(capacity),
+        }
+    }
 }
 
 /// Tokens/sec and KV-cache trends for one inference server.
@@ -238,6 +264,7 @@ impl Collector {
             refresh_kind,
             proc_refresh,
             gpu_monitor: GpuMonitor::new(),
+            gpu_history: Vec::new(),
             infer_monitor: InferenceMonitor::with_targets(targets),
             prev_proc_io: std::collections::HashMap::new(),
             last_instant: None,
@@ -310,6 +337,7 @@ impl Collector {
                 p.gpu_mem = vram.get(&p.pid).copied().unwrap_or(0);
             }
         }
+        self.update_gpu_history();
         self.servers = self.infer_monitor.snapshot();
         self.update_server_history();
         // Battery level moves on the order of minutes; poll it at most this
@@ -327,6 +355,27 @@ impl Collector {
 
     /// Append this tick's tokens/sec and KV% to each live server's history,
     /// dropping the histories of servers that vanished.
+    /// Keep one history per GPU, resizing when GPUs appear or disappear.
+    /// A GPU that stops reporting utilization pushes 0 rather than nothing, so
+    /// the time axis stays honest — a gap would silently compress the graph.
+    fn update_gpu_history(&mut self) {
+        if self.gpu_history.len() != self.gpus.len() {
+            self.gpu_history = (0..self.gpus.len())
+                .map(|_| GpuHistory::new(self.history_len))
+                .collect();
+        }
+        for (g, h) in self.gpus.iter().zip(self.gpu_history.iter_mut()) {
+            h.compute
+                .push(if g.has_util { g.util_pct as f64 } else { 0.0 });
+            h.bandwidth.push(if g.has_mem_util {
+                g.mem_util as f64
+            } else {
+                0.0
+            });
+            h.vram.push(g.mem_pct() as f64);
+        }
+    }
+
     fn update_server_history(&mut self) {
         let live: std::collections::HashSet<(u32, u16)> =
             self.servers.iter().map(|s| (s.pid, s.port)).collect();
@@ -744,6 +793,71 @@ fn status_char(status: ProcessStatus) -> char {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fake_gpu(util: f32, mem_util: f32, used: u64, total: u64) -> gpu::Gpu {
+        gpu::Gpu {
+            name: "TestGPU".into(),
+            util_pct: util,
+            has_util: true,
+            mem_util,
+            has_mem_util: true,
+            mem_used: used,
+            mem_total: total,
+            temp: 60.0,
+            power: 200.0,
+            power_limit: 400.0,
+            throttled: false,
+        }
+    }
+
+    #[test]
+    fn gpu_history_tracks_compute_bandwidth_and_vram() {
+        let mut c = Collector::new(8);
+        c.gpus = vec![fake_gpu(90.0, 30.0, 50, 100)];
+        c.update_gpu_history();
+        c.gpus = vec![fake_gpu(20.0, 95.0, 90, 100)];
+        c.update_gpu_history();
+
+        assert_eq!(c.gpu_history.len(), 1);
+        let h = &c.gpu_history[0];
+        assert_eq!(h.compute.tail(2), vec![90.0, 20.0]);
+        // The divergence this graph exists to show: compute fell, bandwidth
+        // pinned — memory-bound, and a faster GPU core would not help.
+        assert_eq!(h.bandwidth.tail(2), vec![30.0, 95.0]);
+        assert_eq!(h.vram.tail(2), vec![50.0, 90.0]);
+    }
+
+    #[test]
+    fn gpu_history_resizes_when_gpus_come_and_go() {
+        let mut c = Collector::new(8);
+        c.gpus = vec![fake_gpu(50.0, 50.0, 1, 2), fake_gpu(50.0, 50.0, 1, 2)];
+        c.update_gpu_history();
+        assert_eq!(c.gpu_history.len(), 2);
+        // A GPU disappearing (driver reload, container restart) resizes rather
+        // than indexing past the end.
+        c.gpus.pop();
+        c.update_gpu_history();
+        assert_eq!(c.gpu_history.len(), 1);
+        c.gpus.clear();
+        c.update_gpu_history();
+        assert!(c.gpu_history.is_empty());
+    }
+
+    #[test]
+    fn gpu_without_utilization_still_advances_the_time_axis() {
+        let mut c = Collector::new(8);
+        let mut g = fake_gpu(0.0, 0.0, 10, 100);
+        g.has_util = false;
+        g.has_mem_util = false;
+        c.gpus = vec![g];
+        c.update_gpu_history();
+        let before = c.gpu_history[0].compute.len();
+        c.update_gpu_history();
+        // Pushing 0 rather than nothing keeps the time axis honest — a gap
+        // would silently compress the graph.
+        assert_eq!(c.gpu_history[0].compute.len(), before + 1);
+        assert_eq!(c.gpu_history[0].compute.last(), 0.0);
+    }
 
     #[test]
     fn server_history_tracks_and_prunes() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1183,6 +1183,40 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
                 dim(theme),
             )));
         }
+        // Compute vs memory-bandwidth over time, mirrored around a midline.
+        // Token generation is bandwidth-bound once the model is resident, so
+        // the *divergence* between these two lines is the diagnosis: bandwidth
+        // pinned while compute idles means you are memory-bound, and no amount
+        // of a faster GPU core will help.
+        if let Some(h) = c.gpu_history.get(i) {
+            let graph_h = 4usize;
+            if h.compute.len() >= 2 && bw >= 12 && lines.len() + graph_h + 1 < inner.height as usize
+            {
+                lines.push(Line::from(vec![
+                    Span::styled(format!("  {:<10}", "trend"), dim(theme)),
+                    Span::styled("compute ▲", Style::default().fg(theme.accent.color())),
+                    Span::styled("  /  ", dim(theme)),
+                    Span::styled("▼ bandwidth", Style::default().fg(theme.accent2.color())),
+                ]));
+                // Only the visible window, so the graph scrolls with time
+                // instead of squeezing an ever-longer history into `bw` cells.
+                let (compute, bandwidth) = (h.compute.tail(bw * 2), h.bandwidth.tail(bw * 2));
+                for line in graph::mirror_graph(
+                    &compute,
+                    &bandwidth,
+                    100.0,
+                    bw,
+                    graph_h,
+                    theme.accent.color(),
+                    theme.accent2.color(),
+                ) {
+                    let mut spans = vec![Span::styled("            ", dim(theme))];
+                    spans.extend(line.spans);
+                    lines.push(Line::from(spans));
+                }
+            }
+        }
+
         lines.push(Line::from(Span::raw("")));
     }
 
@@ -1293,6 +1327,21 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
                     format!("  req {:.0}/{:.0}", r, sv.waiting.unwrap_or(0.0)),
                     dim(theme),
                 ));
+            }
+            // Preemption is the signal nothing else surfaces: the server threw
+            // away work it had already done because the KV cache ran out.
+            // Throughput collapses while the GPU still looks busy.
+            if let Some(rate) = sv.preempt_rate.filter(|r| *r > 0.0) {
+                stat.push(Span::styled(
+                    format!("  ⟲ preempt {rate:.1}/s"),
+                    Style::default()
+                        .fg(theme.grad(1.0))
+                        .add_modifier(Modifier::BOLD),
+                ));
+            } else if let Some(total) = sv.preemptions.filter(|t| *t > 0.0) {
+                // Not preempting now, but it has — worth knowing this server
+                // has been under KV pressure at some point.
+                stat.push(Span::styled(format!("  ⟲ {total:.0} total"), dim(theme)));
             }
             // Only fall back to the mean TTFT when no histogram was available;
             // the percentile line below says strictly more.

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -160,6 +160,8 @@ fn ai_view_renders() {
         }),
         gpu_offload_pct: None,
         addr: None,
+        preemptions: Some(12.0),
+        preempt_rate: Some(1.2),
     }];
     render_at(&mut app, 100, 30);
     render_at(&mut app, 60, 14); // cramped


### PR DESCRIPTION
> ⚠️ **Stacked on #69** (`feat/inference-telemetry`), which refactored the counter-rate path this builds on. Merge #69 first.

Two signals a serving engineer needs that **no other terminal tool shows**.

### #31 — KV-cache preemption
When a serving runtime runs out of KV cache it **preempts** in-flight requests: work already done is thrown away and recomputed later. Throughput collapses, latency spikes — and `nvidia-smi`, `nvtop` and every GPU dashboard still show a busy, healthy GPU. Because the GPU *is* busy. It's busy redoing work.

```
  vLLM:8000  Llama-3-8B
    83.4 tok/s  prefill 1200/s  kv 99%  req 4/12  ⟲ preempt 1.8/s
```

toptop scrapes vLLM's `num_preemptions_total` (both spellings across versions) and TensorRT-LLM's equivalent, differences it into a rate, and raises a **critical** alert on a sustained nonzero rate — deliberately ranked above a queue backlog, because a backlog only *delays* work whereas preemption *destroys* work already done.

Edge cases that matter for a counter: a reset (server restart) yields no rate rather than a negative one, and an absent counter reads as "no data" rather than "zero preemptions".

Tunable via `alert_preempt` / `--alert-preempt`; exported as `toptop_inference_preemptions_{total,per_second}`.

### #32 — compute vs bandwidth, over time
Per-GPU histories of compute, memory-bandwidth and VRAM, drawn as one **mirrored braille graph** — compute above the midline, bandwidth below (reusing the tested `mirror_graph` that already draws network up/down):

```
  trend      compute ▲  /  ▼ bandwidth
             ⢀⣀⣠⣤⣶⣶⣤⣄⣀⡀⢀⣀⣠⣤⣶
             ⠉⠛⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
```

This is the AI view's defining framing made temporal. Token generation is memory-bandwidth-bound once the model is resident, so **bandwidth pinned while compute idles means you are memory-bound and a faster GPU core will not help you**. That divergence is only visible over time.

A GPU that stops reporting utilization pushes 0 rather than nothing, so the time axis stays honest — a gap would silently compress the graph. The history resizes when GPUs appear or disappear (driver reload, container restart).

### Verification
- `cargo test` — 132 green (was 126 on the base branch). New: counter parsing incl. both spellings and the absent-counter case, rate differencing across scrapes incl. counter reset, preemption alert severity and thresholding, GPU history tracking, resizing on GPU add/remove, and the no-utilization case.
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean.
- `--demo` now preempts once KV saturates, so the whole story is visible with `toptop --demo` on a machine with no GPU.

Closes #31, closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X