### PR TITLE
AI view: wrap instead of clipping, and no trend over blank rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The AI view no longer clips facts at the panel border.** The per-server
+  stat line is a variable-length list, and whatever came last — usually the
+  preemption rate, the most actionable number on it — was silently cut off.
+  It now wraps between facts, never through one. Alert messages truncate with
+  an ellipsis instead of being cut mid-word by the border.
+- **No "trend" heading over blank rows.** A GPU that reports no utilization
+  (Apple Silicon, most integrated GPUs) drew the compute-vs-bandwidth heading
+  above four permanently empty rows.
+
 - **Unified-memory GPUs no longer render as `vram 0 B / 0 B`.** Apple Silicon
   reports no discrete VRAM total, which the small GPU panel drew as a
   zero-byte reading — indistinguishable from a broken driver. It now says

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-166%20green-success)
+![Tests](https://img.shields.io/badge/tests-167%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1270,7 +1270,13 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
                     format!("  [{}] ", a.level.label()),
                     Style::default().fg(theme.grad(if hot { 1.0 } else { 0.7 })),
                 ),
-                Span::styled(a.message.clone(), Style::default().fg(theme.fg.color())),
+                // Truncate with an ellipsis rather than letting the panel
+                // border clip mid-word — a cut-off alert reads as a rendering
+                // bug on top of whatever it was warning about.
+                Span::styled(
+                    truncate(&a.message, (inner.width as usize).saturating_sub(9)),
+                    Style::default().fg(theme.fg.color()),
+                ),
             ]));
         }
         lines.push(Line::from(Span::raw("")));
@@ -1388,7 +1394,14 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
         // of a faster GPU core will help.
         if let Some(h) = c.gpu_history.get(i) {
             let graph_h = 4usize;
-            if h.compute.len() >= 2 && bw >= 12 && lines.len() + graph_h + 1 < inner.height as usize
+            // A GPU that reports no utilization at all (Apple Silicon, most
+            // integrated GPUs) would otherwise get a "trend" heading over four
+            // permanently blank rows.
+            let has_signal = h.compute.max() > 0.0 || h.bandwidth.max() > 0.0;
+            if has_signal
+                && h.compute.len() >= 2
+                && bw >= 12
+                && lines.len() + graph_h + 1 < inner.height as usize
             {
                 lines.push(Line::from(vec![
                     Span::styled(format!("  {:<10}", "trend"), dim(theme)),
@@ -1547,7 +1560,10 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
                 stat.push(Span::styled(format!("  ttft {:.0}ms", t), dim(theme)));
             }
             if stat.len() > 1 {
-                lines.push(Line::from(stat));
+                // The stats are a variable-length list of facts; on a narrow
+                // panel they used to be clipped mid-word at the border, which
+                // silently hid whichever fact came last — including preemption.
+                lines.extend(wrap_spans(stat, inner.width as usize, "  "));
             }
 
             // Prefill vs decode as a first-class split: the two phases have
@@ -1768,6 +1784,29 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
     let target = block.inner(rect);
     f.render_widget(block, rect);
     f.render_widget(Paragraph::new(Text::from(lines)), target);
+}
+
+/// Pack `spans` into lines of at most `width` cells, indenting continuations
+/// with `indent`. Splits only between spans — each one is a self-contained
+/// fact, and half a fact is worse than a wrapped one.
+fn wrap_spans<'a>(spans: Vec<Span<'a>>, width: usize, indent: &'a str) -> Vec<Line<'a>> {
+    let mut lines = Vec::new();
+    let mut current: Vec<Span<'a>> = Vec::new();
+    let mut used = 0usize;
+    for span in spans {
+        let len = span.content.chars().count();
+        if used + len > width && !current.is_empty() {
+            lines.push(Line::from(std::mem::take(&mut current)));
+            current.push(Span::raw(indent));
+            used = indent.chars().count();
+        }
+        used += len;
+        current.push(span);
+    }
+    if !current.is_empty() {
+        lines.push(Line::from(current));
+    }
+    lines
 }
 
 /// Whether a rendered line carries no visible text.

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -610,3 +610,57 @@ fn duplicate_mounts_are_deduplicated() {
         );
     }
 }
+
+/// The AI view must not clip facts at the panel border, and must not draw a
+/// trend heading over blank rows for a GPU that reports no utilization.
+#[test]
+fn the_ai_view_wraps_instead_of_clipping() {
+    use toptop::metrics::ServerStats;
+
+    let mut app = App::new(&Config::default());
+    // A GPU that reports nothing — Apple Silicon, most integrated GPUs.
+    app.collector.gpus = vec![toptop::metrics::gpu::Gpu {
+        name: "Apple M3".into(),
+        util_pct: 0.0,
+        has_util: false,
+        mem_util: 0.0,
+        has_mem_util: false,
+        mem_used: 0,
+        mem_total: 0,
+        temp: 0.0,
+        power: 0.0,
+        power_limit: 0.0,
+        throttled: false,
+    }];
+    // A server with every stat populated, so the line is at its longest.
+    app.collector.servers = vec![ServerStats {
+        runtime: "vLLM",
+        pid: 4242,
+        port: 8000,
+        model: "meta-llama/Llama-3-8B".into(),
+        gen_tps: Some(83.4),
+        prompt_tps: Some(1240.0),
+        running: Some(2.0),
+        waiting: Some(5.0),
+        kv_pct: Some(64.0),
+        ttft_ms: Some(180.0),
+        preemptions: Some(12.0),
+        preempt_rate: Some(1.2),
+        ..Default::default()
+    }];
+    app.show_ai = true;
+    let screen = render_text(&mut app, 118, 40);
+    let joined = screen.join("\n");
+
+    // Preemption is the most important fact on that line and used to be the
+    // one clipped off the end.
+    assert!(
+        joined.contains("preempt 1.2/s"),
+        "the preemption rate was clipped:\n{joined}"
+    );
+    // No "trend" heading without a trend to show.
+    assert!(
+        !joined.contains("compute ▲"),
+        "a GPU reporting no utilization drew a trend over blank rows:\n{joined}"
+    );
+}


### PR DESCRIPTION
Two things visible the moment the newly-merged features render together.

### Facts were being clipped off the end of the line
The per-server stat line is a variable-length list of facts, and at 78 columns it ran past the panel border. ratatui clips rather than wraps, so whatever came last was **silently gone** — which after #76 meant the preemption rate, the most actionable number on the line:

```
    83.4 tok/s (0.29 tok/s/W)  prefill 1240/s  kv 64%  req 2/5  ⟲ preempt 1.│   ← cut
```

Now it wraps *between* facts, with a continuation indent. Splitting through a fact would be worse than wrapping:

```
    83.4 tok/s (0.29 tok/s/W)  prefill 1240/s  kv 64%  req 2/5
    ⟲ preempt 1.2/s
```

Alert messages get the same treatment via an ellipsis — a cut-off alert reads as a rendering bug on top of whatever it was warning about.

### A trend heading over four blank rows
The compute-vs-bandwidth graph drew its heading even when the history carried no signal — i.e. **permanently, on Apple Silicon and most integrated GPUs**, which report no utilization at all. The block is now skipped unless there is something to plot.

### Verification
- `cargo test` — 167 green. New test renders the AI view with a no-utilization GPU and a fully-populated server, asserting the preemption rate survives and no trend heading appears.
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X