### PR TITLE
Responsive process table: drop columns instead of squeezing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The process table drops columns on narrow terminals** instead of squeezing
+  all of them into unreadable stubs (`PI USE CP ME ME DIS VR TI S`). Columns
+  go by usefulness — `USER`, `TIME`, `DISK` first — while `PID` and `COMMAND`
+  are never dropped, so a row stays identifiable. Click-to-sort follows the
+  columns actually drawn, so the header and the hit map can't disagree.
+
 ### Fixed
 
 - **Unified-memory GPUs no longer render as `vram 0 B / 0 B`.** Apple Silicon

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-167%20green-success)
+![Tests](https://img.shields.io/badge/tests-170%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 
@@ -574,6 +574,11 @@ columns = pid, cpu, mem%, vram, command
 Available: `pid` · `user` · `cpu` · `mem%` · `mem` · `disk` · `vram` · `time` ·
 `state` · `command`. Unknown names are ignored; the header, the rows and
 click‑to‑sort all follow the configured set.
+
+On a terminal too narrow for the configured set, columns are **dropped rather
+than squeezed** — `USER`, `TIME` and `DISK` go first, and `PID` and `COMMAND`
+never go at all, so a row stays identifiable. Ten columns crammed into 40 cells
+is ten useless columns; four readable ones are strictly better.
 
 ### Keybindings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,6 +137,24 @@ impl ProcColumn {
         }
     }
 
+    /// Drop priority when the terminal is too narrow for every column: higher
+    /// goes first. PID and the command line are what make a row identifiable
+    /// at all, so they are never dropped; CPU and memory are why you are
+    /// looking. USER and the padding columns go first.
+    fn drop_priority(self) -> u8 {
+        match self {
+            ProcColumn::Pid | ProcColumn::Command => 0, // never dropped
+            ProcColumn::Cpu => 1,
+            ProcColumn::MemPct => 2,
+            ProcColumn::Mem => 3,
+            ProcColumn::State => 4,
+            ProcColumn::Vram => 5,
+            ProcColumn::Disk => 6,
+            ProcColumn::Time => 7,
+            ProcColumn::User => 8,
+        }
+    }
+
     /// Sort field a click on this header selects, if the column is sortable.
     pub fn sort_field(self) -> Option<SortField> {
         match self {
@@ -167,6 +185,38 @@ impl ProcColumn {
             _ => None,
         }
     }
+}
+
+/// Narrow `columns` until they fit `width` cells, dropping the least useful
+/// ones first (see [`ProcColumn::drop_priority`]).
+///
+/// Squeezing ten columns into a 40-cell terminal produces a row of unreadable
+/// stubs — `PI USE CP ME ME DIS VR TI S` — where every column is useless.
+/// Dropping some so the rest stay legible is strictly better, and the ones
+/// that identify the process are never among them.
+pub fn fit_columns(columns: &[ProcColumn], width: u16) -> Vec<ProcColumn> {
+    // Every fixed column costs its width plus one cell of spacing, and the
+    // command column needs a usable minimum of its own.
+    const COMMAND_MIN: u16 = 12;
+    let cost = |c: &ProcColumn| c.width().map(|w| w + 1).unwrap_or(COMMAND_MIN + 1);
+
+    let mut kept: Vec<ProcColumn> = columns.to_vec();
+    let total = |cols: &[ProcColumn]| -> u16 { cols.iter().map(cost).sum() };
+
+    while total(&kept) > width && kept.len() > 1 {
+        // Drop the highest-priority droppable column; stop if only
+        // never-dropped ones remain.
+        let Some((idx, _)) = kept
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.drop_priority() > 0)
+            .max_by_key(|(_, c)| c.drop_priority())
+        else {
+            break;
+        };
+        kept.remove(idx);
+    }
+    kept
 }
 
 /// Sort key for the combined per-process I/O rate.
@@ -259,6 +309,9 @@ pub struct App {
     pub sort_desc: bool,
     /// Process-table columns, in display order (from the config).
     pub columns: Vec<ProcColumn>,
+    /// The subset actually drawn at the current width, captured at render time
+    /// so click-to-sort maps against what the user can see.
+    pub visible_columns: Vec<ProcColumn>,
     /// Key → action bindings (from the config).
     pub keys: KeyMap,
     pub filter: String,
@@ -337,6 +390,7 @@ impl App {
             sort: SortField::Cpu,
             sort_desc: true,
             columns: cfg.columns.clone(),
+            visible_columns: cfg.columns.clone(),
             keys: cfg.keys.clone(),
             filter: String::new(),
             filter_mode: false,
@@ -1015,7 +1069,7 @@ impl App {
                 let area = self.proc_area;
                 // Header row sits one line above the data rows: click to sort.
                 if area.height > 0 && ev.row + 1 == area.y && ev.column >= area.x {
-                    if let Some(field) = header_sort_at(&self.columns, ev.column - area.x) {
+                    if let Some(field) = header_sort_at(&self.visible_columns, ev.column - area.x) {
                         if self.sort == field {
                             self.sort_desc = !self.sort_desc;
                         } else {
@@ -1123,6 +1177,53 @@ mod tests {
         app.on_key(key(KeyCode::Char('i')));
         assert!(!app.sort_desc);
         assert_eq!(pids(&app), vec![1, 3, 2]);
+    }
+
+    #[test]
+    fn narrow_terminals_drop_columns_by_priority() {
+        let all = DEFAULT_COLUMNS;
+
+        // Wide enough for everything: nothing is dropped.
+        assert_eq!(fit_columns(all, 200), all.to_vec());
+
+        // Progressively narrower keeps a strictly shrinking subset.
+        let mut previous = all.len() + 1;
+        for width in [120u16, 100, 80, 60, 50, 40, 30, 20] {
+            let kept = fit_columns(all, width);
+            assert!(
+                kept.len() <= previous,
+                "width {width} kept more columns than a wider terminal"
+            );
+            previous = kept.len();
+
+            // The two columns that identify a row survive every width.
+            assert!(
+                kept.contains(&ProcColumn::Pid),
+                "PID dropped at width {width}"
+            );
+            assert!(
+                kept.contains(&ProcColumn::Command),
+                "COMMAND dropped at width {width}"
+            );
+            // Order is never shuffled, only thinned.
+            let order: Vec<_> = all.iter().filter(|c| kept.contains(c)).copied().collect();
+            assert_eq!(kept, order, "column order changed at width {width}");
+        }
+
+        // USER goes before CPU%: you look at a process monitor for load.
+        let narrow = fit_columns(all, 45);
+        assert!(narrow.contains(&ProcColumn::Cpu));
+        assert!(!narrow.contains(&ProcColumn::User));
+    }
+
+    #[test]
+    fn click_to_sort_follows_the_visible_columns() {
+        // After dropping USER, the second column is CPU%, and a click there
+        // must sort by CPU rather than by whatever used to be at that offset.
+        let narrow = fit_columns(DEFAULT_COLUMNS, 45);
+        assert_eq!(narrow[0], ProcColumn::Pid);
+        assert_eq!(header_sort_at(&narrow, 0), Some(SortField::Pid));
+        assert_eq!(header_sort_at(&narrow, 8), Some(SortField::Cpu));
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -752,7 +752,11 @@ fn render_procs(f: &mut Frame, area: Rect, app: &mut App) {
         height: rows_cap as u16,
     };
 
-    let columns = app.columns.clone();
+    // Narrow terminals drop columns rather than squeezing all of them into
+    // unreadable stubs. The result also drives click-to-sort, so the header
+    // and the hit map can't disagree.
+    let columns = crate::app::fit_columns(&app.columns, inner.width);
+    app.visible_columns = columns.clone();
     let header = Row::new(
         columns
             .iter()

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -638,3 +638,40 @@ fn ai_workloads_are_cached_per_tick() {
         "closing the view drops the cache"
     );
 }
+
+/// A narrow terminal must show fewer, readable columns rather than ten
+/// unreadable stubs.
+#[test]
+fn the_process_table_drops_columns_when_narrow() {
+    let mut app = App::new(&Config::default());
+
+    let wide = render_text(&mut app, 120, 12);
+    let wide_header = wide
+        .iter()
+        .find(|l| l.contains("PID"))
+        .expect("header")
+        .clone();
+    assert!(wide_header.contains("USER"), "wide: {wide_header:?}");
+    assert!(wide_header.contains("COMMAND"), "wide: {wide_header:?}");
+
+    let narrow = render_text(&mut app, 44, 12);
+    let narrow_header = narrow
+        .iter()
+        .find(|l| l.contains("PID"))
+        .expect("header")
+        .clone();
+    // Fewer columns, but still the ones that identify and rank a process.
+    assert!(!narrow_header.contains("USER"), "narrow: {narrow_header:?}");
+    assert!(narrow_header.contains("CPU%"), "narrow: {narrow_header:?}");
+    assert!(
+        narrow_header.contains("COMMAND"),
+        "narrow: {narrow_header:?}"
+    );
+    // And no truncated stubs: every retained heading is intact.
+    for heading in ["PID", "CPU%", "COMMAND"] {
+        assert!(
+            narrow_header.contains(heading),
+            "{heading} was clipped: {narrow_header:?}"
+        );
+    }
+}


### PR DESCRIPTION
At 40 columns the table rendered ten columns, none of them readable:

```
│PI USE CP ME ME DIS VR TI S COMMAND   │
│   snu  1    17 ·   ·  00 R target/deb│
```

Ten useless columns are worse than four useful ones:

```
│PID     CPU%  MEM%  COMMAND           │
│  85609  43.2   0.1 /System/Library/Pr│
```

### How
`fit_columns` drops the least useful columns until the rest fit, by an explicit priority:

| Priority | Columns | Rationale |
|---|---|---|
| never dropped | `PID`, `COMMAND` | without them a row isn't identifiable |
| kept longest | `CPU%`, `MEM%` | why you opened a process monitor |
| middle | `MEM`, `S`, `VRAM` | |
| dropped first | `DISK`, `TIME`, `USER` | |

The surviving set is captured at render time as `App::visible_columns`, and **click-to-sort maps against that** rather than the configured set — otherwise the header and the hit map would silently disagree the moment a column dropped.

Builds on the data-driven column set from #65, as flagged in #74.

### Verification
- `cargo test` — 170 green. New: monotonic thinning across eight widths, PID/COMMAND survival at every width, order preserved (thinned, never shuffled), USER dropping before CPU%, click-to-sort offsets after a drop, and a rendered-buffer test asserting the narrow header is a smaller *complete* set rather than clipped stubs.
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X