### PR TITLE
Refresh the Grafana dashboard, and stop it rotting again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The shipped Grafana dashboard covers the new signals** — panels for the
+  TTFT and TPOT percentile triads, KV-cache preemptions/sec (with a threshold
+  at the alerting default), the prefill-vs-decode split and GPU throttling. A
+  new test cross-checks every `toptop_*` name in the dashboard against the
+  exporter's own `# TYPE` declarations, so a renamed metric fails CI instead of
+  silently blanking a panel for everyone; it also asserts the panels don't
+  overlap on the 24-column grid. (#7)
+
 ### Added
 
 - **cgroup v2 awareness** — inside a container, the CPU panel now shows the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-188%20green-success)
+![Tests](https://img.shields.io/badge/tests-191%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 

--- a/assets/grafana/toptop-dashboard.json
+++ b/assets/grafana/toptop-dashboard.json
@@ -1,104 +1,384 @@
 {
-  "__inputs": [
+ "__inputs": [
+  {
+   "name": "DS_PROMETHEUS",
+   "label": "Prometheus",
+   "type": "datasource",
+   "pluginId": "prometheus",
+   "pluginName": "Prometheus"
+  }
+ ],
+ "title": "toptop \u00b7 local inference",
+ "uid": "toptop-inference",
+ "tags": [
+  "toptop",
+  "llm",
+  "gpu",
+  "inference"
+ ],
+ "timezone": "browser",
+ "schemaVersion": 39,
+ "refresh": "10s",
+ "time": {
+  "from": "now-30m",
+  "to": "now"
+ },
+ "panels": [
+  {
+   "id": 1,
+   "type": "timeseries",
+   "title": "Tokens / second (generation)",
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 0
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short",
+     "min": 0
+    },
+    "overrides": []
+   },
+   "targets": [
     {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+     "expr": "toptop_inference_tokens_per_second",
+     "legendFormat": "{{runtime}} {{model}}"
     }
-  ],
-  "title": "toptop · local inference",
-  "uid": "toptop-inference",
-  "tags": ["toptop", "llm", "gpu", "inference"],
-  "timezone": "browser",
-  "schemaVersion": 39,
-  "refresh": "10s",
-  "time": { "from": "now-30m", "to": "now" },
-  "panels": [
+   ]
+  },
+  {
+   "id": 2,
+   "type": "timeseries",
+   "title": "GPU: compute vs memory bandwidth (%)",
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 0
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "percent",
+     "min": 0,
+     "max": 100
+    },
+    "overrides": []
+   },
+   "targets": [
     {
-      "id": 1,
-      "type": "timeseries",
-      "title": "Tokens / second (generation)",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
-      "targets": [
-        {
-          "expr": "toptop_inference_tokens_per_second",
-          "legendFormat": "{{runtime}} {{model}}"
-        }
-      ]
+     "expr": "toptop_gpu_util_percent",
+     "legendFormat": "compute gpu{{gpu}}"
     },
     {
-      "id": 2,
-      "type": "timeseries",
-      "title": "GPU: compute vs memory bandwidth (%)",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
-      "targets": [
-        { "expr": "toptop_gpu_util_percent", "legendFormat": "compute gpu{{gpu}}" },
-        { "expr": "toptop_gpu_mem_bandwidth_percent", "legendFormat": "mem b/w gpu{{gpu}}" }
-      ]
-    },
-    {
-      "id": 3,
-      "type": "timeseries",
-      "title": "VRAM used vs total",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "min": 0 }, "overrides": [] },
-      "targets": [
-        { "expr": "toptop_gpu_mem_used_bytes", "legendFormat": "used gpu{{gpu}}" },
-        { "expr": "toptop_gpu_mem_total_bytes", "legendFormat": "total gpu{{gpu}}" }
-      ]
-    },
-    {
-      "id": 4,
-      "type": "timeseries",
-      "title": "KV cache & queue",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
-      "targets": [
-        { "expr": "toptop_inference_kv_cache_percent", "legendFormat": "kv % {{runtime}}" },
-        { "expr": "toptop_inference_requests_waiting", "legendFormat": "queued {{runtime}}" },
-        { "expr": "toptop_inference_requests_running", "legendFormat": "running {{runtime}}" }
-      ]
-    },
-    {
-      "id": 5,
-      "type": "timeseries",
-      "title": "GPU power & temperature",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
-      "targets": [
-        { "expr": "toptop_gpu_power_watts", "legendFormat": "watts gpu{{gpu}}" },
-        { "expr": "toptop_gpu_temp_celsius", "legendFormat": "°C gpu{{gpu}}" }
-      ]
-    },
-    {
-      "id": 6,
-      "type": "table",
-      "title": "Firing alerts (VRAM spill · throttle · KV · queue)",
-      "gridPos": { "h": 6, "w": 16, "x": 0, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "targets": [
-        { "expr": "toptop_alert", "format": "table", "instant": true }
-      ]
-    },
-    {
-      "id": 7,
-      "type": "stat",
-      "title": "TTFT (ms)",
-      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
-      "targets": [
-        { "expr": "toptop_inference_ttft_ms", "legendFormat": "{{runtime}}" }
-      ]
+     "expr": "toptop_gpu_mem_bandwidth_percent",
+     "legendFormat": "mem b/w gpu{{gpu}}"
     }
-  ]
+   ]
+  },
+  {
+   "id": 3,
+   "type": "timeseries",
+   "title": "VRAM used vs total",
+   "gridPos": {
+    "h": 8,
+    "w": 8,
+    "x": 0,
+    "y": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes",
+     "min": 0
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_gpu_mem_used_bytes",
+     "legendFormat": "used gpu{{gpu}}"
+    },
+    {
+     "expr": "toptop_gpu_mem_total_bytes",
+     "legendFormat": "total gpu{{gpu}}"
+    }
+   ]
+  },
+  {
+   "id": 4,
+   "type": "timeseries",
+   "title": "KV cache & queue",
+   "gridPos": {
+    "h": 8,
+    "w": 8,
+    "x": 8,
+    "y": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short",
+     "min": 0
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_inference_kv_cache_percent",
+     "legendFormat": "kv % {{runtime}}"
+    },
+    {
+     "expr": "toptop_inference_requests_waiting",
+     "legendFormat": "queued {{runtime}}"
+    },
+    {
+     "expr": "toptop_inference_requests_running",
+     "legendFormat": "running {{runtime}}"
+    }
+   ]
+  },
+  {
+   "id": 5,
+   "type": "timeseries",
+   "title": "GPU power & temperature",
+   "gridPos": {
+    "h": 8,
+    "w": 8,
+    "x": 16,
+    "y": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short",
+     "min": 0
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_gpu_power_watts",
+     "legendFormat": "watts gpu{{gpu}}"
+    },
+    {
+     "expr": "toptop_gpu_temp_celsius",
+     "legendFormat": "\u00b0C gpu{{gpu}}"
+    }
+   ]
+  },
+  {
+   "id": 6,
+   "type": "table",
+   "title": "Firing alerts (VRAM spill \u00b7 throttle \u00b7 KV \u00b7 queue)",
+   "gridPos": {
+    "h": 6,
+    "w": 24,
+    "x": 0,
+    "y": 16
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "targets": [
+    {
+     "expr": "toptop_alert",
+     "format": "table",
+     "instant": true
+    }
+   ]
+  },
+  {
+   "id": 7,
+   "type": "timeseries",
+   "title": "Latency SLO: TTFT p50/p95/p99",
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 22
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "ms"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_inference_ttft_p50_ms",
+     "legendFormat": "{{runtime}} p50"
+    },
+    {
+     "expr": "toptop_inference_ttft_p95_ms",
+     "legendFormat": "{{runtime}} p95"
+    },
+    {
+     "expr": "toptop_inference_ttft_p99_ms",
+     "legendFormat": "{{runtime}} p99"
+    }
+   ],
+   "description": "Time to first token \u2014 how long until anything appears. p95/p99 are what users actually feel; the mean hides the tail."
+  },
+  {
+   "id": 8,
+   "type": "timeseries",
+   "title": "Latency SLO: TPOT p50/p95/p99",
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 22
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "ms"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_inference_tpot_p50_ms",
+     "legendFormat": "{{runtime}} p50"
+    },
+    {
+     "expr": "toptop_inference_tpot_p95_ms",
+     "legendFormat": "{{runtime}} p95"
+    },
+    {
+     "expr": "toptop_inference_tpot_p99_ms",
+     "legendFormat": "{{runtime}} p99"
+    }
+   ],
+   "description": "Time per output token \u2014 the inter-token latency while a response streams. Rising TPOT with flat TTFT means decode is degrading."
+  },
+  {
+   "id": 9,
+   "type": "timeseries",
+   "title": "KV-cache preemptions/sec",
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 30
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "reqps",
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 0.2
+       }
+      ]
+     }
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_inference_preemptions_per_second",
+     "legendFormat": "{{runtime}}:{{port}}"
+    }
+   ],
+   "description": "Requests evicted mid-flight because the KV cache ran out, and later recomputed. Anything above zero is throughput being destroyed while the GPU still looks busy \u2014 no other tool surfaces this."
+  },
+  {
+   "id": 10,
+   "type": "timeseries",
+   "title": "Prefill vs decode throughput",
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 30
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "none"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_inference_prefill_tokens_per_second",
+     "legendFormat": "{{runtime}} prefill"
+    },
+    {
+     "expr": "toptop_inference_tokens_per_second",
+     "legendFormat": "{{runtime}} decode"
+    }
+   ],
+   "description": "The two phases have different bottlenecks: prefill is compute-bound, decode is memory-bandwidth-bound. The mix tells you which you are paying for."
+  },
+  {
+   "id": 11,
+   "type": "timeseries",
+   "title": "GPU throttling",
+   "gridPos": {
+    "h": 6,
+    "w": 24,
+    "x": 0,
+    "y": 38
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "none"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "expr": "toptop_gpu_throttled",
+     "legendFormat": "gpu{{gpu}} {{name}}"
+    }
+   ],
+   "description": "1 while the driver reports an active power or thermal throttle. Every other reading is measured on a throttled card."
+  }
+ ]
 }

--- a/tests/dashboard.rs
+++ b/tests/dashboard.rs
@@ -1,0 +1,156 @@
+//! The shipped Grafana dashboard must reference metrics toptop actually
+//! exports.
+//!
+//! A dashboard is documentation that silently rots: rename a metric and the
+//! panel just goes blank, for everyone, forever. This test reads
+//! `assets/grafana/toptop-dashboard.json`, pulls every `toptop_*` name out of
+//! it, and checks each against the exporter's own `# TYPE` declarations.
+
+use std::collections::HashSet;
+
+use toptop::alerts::AlertConfig;
+use toptop::metrics::{gpu::Gpu, Collector, Percentiles, ServerStats};
+
+/// Every metric name the exporter declares, with a snapshot rigged so that
+/// *all* the conditional families (GPU, inference, alerts) are emitted.
+fn exported_metric_names() -> HashSet<String> {
+    let mut c = Collector::new(16);
+    c.gpus = vec![Gpu {
+        name: "TestGPU".into(),
+        util_pct: 50.0,
+        has_util: true,
+        mem_util: 50.0,
+        has_mem_util: true,
+        mem_used: 99,
+        mem_total: 100,
+        temp: 80.0,
+        power: 400.0,
+        power_limit: 400.0,
+        throttled: true,
+    }];
+    c.servers = vec![ServerStats {
+        runtime: "vLLM",
+        pid: 1,
+        port: 8000,
+        model: "test".into(),
+        gen_tps: Some(1.0),
+        prompt_tps: Some(1.0),
+        running: Some(1.0),
+        waiting: Some(99.0),
+        kv_pct: Some(99.0),
+        ttft_ms: Some(1.0),
+        ttft: Some(Percentiles {
+            p50: 1.0,
+            p95: 2.0,
+            p99: 3.0,
+        }),
+        tpot: Some(Percentiles {
+            p50: 1.0,
+            p95: 2.0,
+            p99: 3.0,
+        }),
+        preemptions: Some(1.0),
+        preempt_rate: Some(1.0),
+        gpu_offload_pct: None,
+        addr: None,
+    }];
+
+    toptop::export::to_prometheus(&c, &AlertConfig::default())
+        .lines()
+        .filter_map(|l| l.strip_prefix("# TYPE "))
+        .filter_map(|l| l.split_whitespace().next())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Pull every `toptop_*` identifier out of the dashboard JSON.
+fn dashboard_metric_names(json: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let bytes = json.as_bytes();
+    let mut i = 0;
+    while let Some(rel) = json[i..].find("toptop_") {
+        let start = i + rel;
+        let mut end = start;
+        while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+            end += 1;
+        }
+        out.insert(json[start..end].to_string());
+        i = end;
+    }
+    out
+}
+
+#[test]
+fn the_shipped_dashboard_only_uses_metrics_we_export() {
+    let json = std::fs::read_to_string("assets/grafana/toptop-dashboard.json")
+        .expect("the dashboard ships with the repo");
+    let used = dashboard_metric_names(&json);
+    assert!(
+        !used.is_empty(),
+        "no metrics found — did the format change?"
+    );
+
+    let exported = exported_metric_names();
+    let missing: Vec<&String> = used.difference(&exported).collect();
+    assert!(
+        missing.is_empty(),
+        "the dashboard references metrics toptop does not export, so those \
+         panels are blank for every user: {missing:?}"
+    );
+}
+
+#[test]
+fn the_dashboard_covers_the_metrics_that_make_toptop_worth_running() {
+    let json = std::fs::read_to_string("assets/grafana/toptop-dashboard.json").unwrap();
+    let used = dashboard_metric_names(&json);
+    // Not every metric needs a panel, but the ones no other tool has do — a
+    // dashboard without them is a dashboard for a generic system monitor.
+    for name in [
+        "toptop_gpu_mem_bandwidth_percent",
+        "toptop_inference_tokens_per_second",
+        "toptop_inference_preemptions_per_second",
+        "toptop_inference_ttft_p95_ms",
+        "toptop_inference_tpot_p95_ms",
+        "toptop_gpu_throttled",
+    ] {
+        assert!(
+            used.contains(name),
+            "{name} has no panel — it is one of the reasons toptop exists"
+        );
+    }
+}
+
+#[test]
+fn the_dashboard_is_valid_json_with_no_overlapping_panels() {
+    let json = std::fs::read_to_string("assets/grafana/toptop-dashboard.json").unwrap();
+    let parsed = toptop::json::parse(&json).expect("valid JSON");
+    let panels = parsed
+        .get("panels")
+        .and_then(toptop::json::Json::as_array)
+        .expect("panels array");
+    assert!(panels.len() >= 8, "suspiciously few panels");
+
+    // Grafana tolerates overlaps by silently reflowing, which turns a tidy
+    // dashboard into a jumbled one on someone else's screen.
+    let boxes: Vec<(i64, i64, i64, i64, String)> = panels
+        .iter()
+        .map(|p| {
+            let g = p.get("gridPos").expect("gridPos");
+            let n = |k: &str| g.num(k).unwrap_or(0.0) as i64;
+            (
+                n("x"),
+                n("y"),
+                n("w"),
+                n("h"),
+                p.str("title").unwrap_or("?").to_string(),
+            )
+        })
+        .collect();
+    for (i, a) in boxes.iter().enumerate() {
+        assert!(a.0 + a.2 <= 24, "{} runs past the 24-column grid", a.4);
+        for b in &boxes[i + 1..] {
+            let overlap = a.0 < b.0 + b.2 && b.0 < a.0 + a.2 && a.1 < b.1 + b.3 && b.1 < a.1 + a.3;
+            assert!(!overlap, "panels overlap: {:?} and {:?}", a.4, b.4);
+        }
+    }
+}


### PR DESCRIPTION
The dashboard shipped in `assets/grafana/` predates most of what makes toptop worth pointing Prometheus at: no TTFT or TPOT percentiles, no preemption, no prefill-vs-decode split, no throttle panel. It also still had a single-value TTFT stat that the percentile triad supersedes.

### New panels
| Panel | Why |
|---|---|
| **Latency SLO: TTFT p50/p95/p99** | the mean hides the tail, and the tail is what users feel |
| **Latency SLO: TPOT p50/p95/p99** | rising TPOT with flat TTFT means decode is degrading |
| **KV-cache preemptions/sec** | throughput being destroyed while the GPU still looks busy — with a red threshold at the alerting default |
| **Prefill vs decode throughput** | the two phases have different bottlenecks |
| **GPU throttling** | every other reading is measured on a throttled card |

The alerts table widens into the space the removed stat left, so there's no hole in the layout.

### The more useful half: `tests/dashboard.rs`
A dashboard is documentation that **rots silently** — rename a metric and the panel just goes blank, for every user, forever. That is exactly what had happened here. Three tests now prevent it:

1. **Every `toptop_*` name in the dashboard is cross-checked against the exporter's own `# TYPE` declarations**, using a rigged snapshot so the conditional families (GPU, inference, alerts) are all emitted. A renamed metric now fails CI.
2. **The metrics that justify having a dashboard at all** — memory bandwidth, preemption, the SLO percentiles, throttling — must have panels. Otherwise it's a dashboard for a generic system monitor.
3. **The JSON parses and no two panels overlap** on the 24-column grid. Grafana silently reflows overlaps into a jumble on someone else's screen.

### Verification
`cargo test` — 191 green. `cargo clippy --all-targets` and `cargo fmt --check` clean.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the Grafana dashboard with p50, p95, and p99 latency panels.
  * Added panels for KV-cache preemptions, prefill versus decode throughput, and GPU throttling.
  * Improved alert-table layout and dashboard readability.

* **Tests**
  * Added validation for dashboard metrics, structure, layout boundaries, and panel overlap.

* **Documentation**
  * Updated the test-status badge to reflect 197 passing tests.
  * Documented OpenTelemetry export options and dashboard metric coverage in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->