### PR TITLE
Make the look coherent: cyberpunk by default, and legible dim text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`cyberpunk` is now the default theme.** The project's banner and hero
+  animation were already drawn in it while a first launch showed gruvbox, so
+  the look that brings people here did not match the one they got. Existing
+  installs are unaffected — the theme is persisted in the config.
+- **The hero animation's palette is read from `src/theme.rs`** instead of being
+  copied into the generator script, so it cannot drift away from the real
+  colours again.
+
+### Fixed
+
+- **Dimmed text is now legible in every built-in theme.** `dim` carries units,
+  key hints, the alert timeline's relative ages and the diagnosis evidence
+  line — it is a visual weight, not permission to be unreadable. It sat at
+  2.5:1 in `matrix` and 3.1:1 in `tokyonight`, well under the 4.5:1 WCAG AA
+  bar. Every built-in now meets it, with hue preserved, and tests enforce the
+  floor for body text, dim text, accents and the full gradient range so it
+  cannot drift back.
+
+### Changed
+
 - **The shipped Grafana dashboard covers the new signals** — panels for the
   TTFT and TPOT percentile triads, KV-cache preemptions/sec (with a threshold
   at the alerting default), the prefill-vs-decode split and GPU throttling. A

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-197%20green-success)
+![Tests](https://img.shields.io/badge/tests-201%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 
@@ -381,6 +381,8 @@ OPTIONS:
 
 ## 🎨 Themes
 
+**`cyberpunk` is the default** — it is the look the banner and the hero
+animation are drawn in, so a first launch matches what brought you here.
 Cycle live with `p` / `P`, or launch with `--theme <name>`:
 
 `gruvbox` &nbsp;·&nbsp; `nord` &nbsp;·&nbsp; `dracula` &nbsp;·&nbsp; `tokyonight` &nbsp;·&nbsp; `matrix` &nbsp;·&nbsp; `cyberpunk` &nbsp;·&nbsp; `paper` (for light backgrounds)
@@ -418,6 +420,7 @@ cargo run --example fleet_preview   # render the fleet dashboard with sample hos
 cargo run -- --snapshot             # one-shot textual snapshot
 python3 scripts/make_banner.py      # regenerate the pixel-art banner (assets/banner.svg)
 python3 scripts/make_ai_demo.py     # regenerate the animated AI-view demo (assets/ai-demo.svg)
+                                    # (its palette is read from src/theme.rs, so it can't drift)
 ```
 
 The render tests drive the **full UI** through ratatui's headless `TestBackend` across

--- a/assets/ai-demo.svg
+++ b/assets/ai-demo.svg
@@ -1,34 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 396" width="760" height="396" font-family="ui-monospace,monospace">
-<rect x="2" y="2" width="756" height="392" rx="12" fill="#282828" stroke="#fe8019" stroke-width="2"/>
-<text x="380.0" y="36" fill="#fe8019" font-size="17" font-weight="bold" text-anchor="middle" font-family="ui-monospace,Menlo,Consolas,monospace" >AI · local-LLM GPU view · Esc/a to close</text>
-<text x="28" y="74" fill="#fb4934" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ ALERTS<animate attributeName="opacity" values="1;0.35;1" dur="1.1s" repeatCount="indefinite"/></text>
-<text x="120" y="74" fill="#ebdbb2" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >[warn] gpu0 VRAM 96% — risk of spilling to RAM (5–20× slower)</text>
-<text x="28" y="112" fill="#83a598" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >gpu0  NVIDIA GeForce RTX 4090</text>
-<text x="732" y="112" fill="#928374" font-size="15" font-weight="normal" text-anchor="end" font-family="ui-monospace,Menlo,Consolas,monospace" >312 / 450 W    71°C</text>
-<text x="40" y="152" fill="#928374" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >compute</text>
-<rect x="188" y="140" width="372" height="16" rx="3" fill="#3c3836"/>
-<rect x="188" y="140" width="115" height="16" rx="3" fill="#b8bb26"></rect>
-<text x="574" y="152" fill="#b8bb26" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >31%</text>
-<text x="40" y="188" fill="#928374" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >mem b/w</text>
-<rect x="188" y="176" width="372" height="16" rx="3" fill="#3c3836"/>
-<rect x="188" y="176" width="290" height="16" rx="3" fill="#fe8019"><animate attributeName="width" values="260;319;275;305;260" dur="3.6s" keyTimes="0;0.25;0.5;0.75;1" calcMode="spline" keySplines=".4 0 .6 1;.4 0 .6 1;.4 0 .6 1;.4 0 .6 1" repeatCount="indefinite"/></rect>
-<text x="574" y="188" fill="#fb4934" font-size="15" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >← bottleneck</text>
-<text x="40" y="224" fill="#928374" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vram</text>
-<rect x="188" y="212" width="372" height="16" rx="3" fill="#3c3836"/>
-<rect x="188" y="212" width="312" height="16" rx="3" fill="#b8bb26"><animate attributeName="width" values="312;360;360;312" dur="6.0s" keyTimes="0;0.5;0.85;1" calcMode="spline" keySplines=".5 0 .5 1;.5 0 .5 1;.5 0 .5 1" repeatCount="indefinite"/><animate attributeName="fill" values="#b8bb26;#fabd2f;#fb4934;#fb4934;#b8bb26" dur="6.0s" keyTimes="0;0.35;0.5;0.85;1" repeatCount="indefinite"/></rect>
-<text x="574" y="224" fill="#928374" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >/ 24 GiB</text>
-<text x="188" y="252" fill="#fb4934" font-size="14" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ near VRAM limit — models will spill to system RAM<animate attributeName="opacity" values="0.15;0.15;1;1;0.15" keyTimes="0;0.35;0.5;0.85;1" dur="6s" repeatCount="indefinite"/></text>
-<line x1="28" y1="278" x2="732" y2="278" stroke="#3c3836" stroke-width="1"/>
-<text x="28" y="308" fill="#fe8019" font-size="16" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >Inference servers (auto-discovered)</text>
-<text x="44" y="336" fill="#83a598" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vLLM :8000</text>
-<text x="160" y="336" fill="#928374" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >meta-llama/Llama-3-8B</text>
-<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">80.6<animate attributeName="opacity" values="1;0;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">82.3<animate attributeName="opacity" values="0;1;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">84.1<animate attributeName="opacity" values="0;0;1;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">85.0<animate attributeName="opacity" values="0;0;0;1;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">83.2<animate attributeName="opacity" values="0;0;0;0;1;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="44" y="372" fill="#b8bb26" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">81.4<animate attributeName="opacity" values="0;0;0;0;0;1" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
-<text x="132" y="372" fill="#b8bb26" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >tok/s</text>
-<text x="220" y="372" fill="#928374" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >·  0.29 tok/s/W   ·   kv 64%   ·   req 2/5   ·   ttft 180 ms</text>
-<rect x="720" y="360" width="10" height="18" fill="#83a598"><animate attributeName="opacity" values="1;1;0;0" dur="1s" repeatCount="indefinite"/></rect>
+<rect x="2" y="2" width="756" height="392" rx="12" fill="#0d061a" stroke="#ff2e97" stroke-width="2"/>
+<text x="380.0" y="36" fill="#ff2e97" font-size="17" font-weight="bold" text-anchor="middle" font-family="ui-monospace,Menlo,Consolas,monospace" >AI · local-LLM GPU view · Esc/a to close</text>
+<text x="28" y="74" fill="#ff295a" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ ALERTS<animate attributeName="opacity" values="1;0.35;1" dur="1.1s" repeatCount="indefinite"/></text>
+<text x="120" y="74" fill="#dcebff" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >[warn] gpu0 VRAM 96% — risk of spilling to RAM (5–20× slower)</text>
+<text x="28" y="112" fill="#00f0ff" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >gpu0  NVIDIA GeForce RTX 4090</text>
+<text x="732" y="112" fill="#826dbd" font-size="15" font-weight="normal" text-anchor="end" font-family="ui-monospace,Menlo,Consolas,monospace" >312 / 450 W    71°C</text>
+<text x="40" y="152" fill="#826dbd" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >compute</text>
+<rect x="188" y="140" width="372" height="16" rx="3" fill="#241734"/>
+<rect x="188" y="140" width="115" height="16" rx="3" fill="#00f0ff"></rect>
+<text x="574" y="152" fill="#00f0ff" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >31%</text>
+<text x="40" y="188" fill="#826dbd" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >mem b/w</text>
+<rect x="188" y="176" width="372" height="16" rx="3" fill="#241734"/>
+<rect x="188" y="176" width="290" height="16" rx="3" fill="#ff2e97"><animate attributeName="width" values="260;319;275;305;260" dur="3.6s" keyTimes="0;0.25;0.5;0.75;1" calcMode="spline" keySplines=".4 0 .6 1;.4 0 .6 1;.4 0 .6 1;.4 0 .6 1" repeatCount="indefinite"/></rect>
+<text x="574" y="188" fill="#ff295a" font-size="15" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >← bottleneck</text>
+<text x="40" y="224" fill="#826dbd" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vram</text>
+<rect x="188" y="212" width="372" height="16" rx="3" fill="#241734"/>
+<rect x="188" y="212" width="312" height="16" rx="3" fill="#00f0ff"><animate attributeName="width" values="312;360;360;312" dur="6.0s" keyTimes="0;0.5;0.85;1" calcMode="spline" keySplines=".5 0 .5 1;.5 0 .5 1;.5 0 .5 1" repeatCount="indefinite"/><animate attributeName="fill" values="#00f0ff;#7b61ff;#ff295a;#ff295a;#00f0ff" dur="6.0s" keyTimes="0;0.35;0.5;0.85;1" repeatCount="indefinite"/></rect>
+<text x="574" y="224" fill="#826dbd" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >/ 24 GiB</text>
+<text x="188" y="252" fill="#ff295a" font-size="14" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >⚠ near VRAM limit — models will spill to system RAM<animate attributeName="opacity" values="0.15;0.15;1;1;0.15" keyTimes="0;0.35;0.5;0.85;1" dur="6s" repeatCount="indefinite"/></text>
+<line x1="28" y1="278" x2="732" y2="278" stroke="#241734" stroke-width="1"/>
+<text x="28" y="308" fill="#ff2e97" font-size="16" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >Inference servers (auto-discovered)</text>
+<text x="44" y="336" fill="#00f0ff" font-size="17" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >vLLM :8000</text>
+<text x="160" y="336" fill="#826dbd" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >meta-llama/Llama-3-8B</text>
+<text x="44" y="372" fill="#00f0ff" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">80.6<animate attributeName="opacity" values="1;0;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#00f0ff" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">82.3<animate attributeName="opacity" values="0;1;0;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#00f0ff" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">84.1<animate attributeName="opacity" values="0;0;1;0;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#00f0ff" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">85.0<animate attributeName="opacity" values="0;0;0;1;0;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#00f0ff" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">83.2<animate attributeName="opacity" values="0;0;0;0;1;0" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="44" y="372" fill="#00f0ff" font-size="20" font-weight="bold" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" opacity="0">81.4<animate attributeName="opacity" values="0;0;0;0;0;1" keyTimes="0.0000;0.1667;0.3333;0.5000;0.6667;0.8333" calcMode="discrete" dur="3.0s" repeatCount="indefinite"/></text>
+<text x="132" y="372" fill="#00f0ff" font-size="16" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >tok/s</text>
+<text x="220" y="372" fill="#826dbd" font-size="15" font-weight="normal" text-anchor="start" font-family="ui-monospace,Menlo,Consolas,monospace" >·  0.29 tok/s/W   ·   kv 64%   ·   req 2/5   ·   ttft 180 ms</text>
+<rect x="720" y="360" width="10" height="18" fill="#00f0ff"><animate attributeName="opacity" values="1;1;0;0" dur="1s" repeatCount="indefinite"/></rect>
 </svg>

--- a/scripts/make_ai_demo.py
+++ b/scripts/make_ai_demo.py
@@ -7,15 +7,48 @@ and the spill alert flashes. Re-run after edits:
     python3 scripts/make_ai_demo.py
 """
 import os
+import re
 
 W, H = 760, 396
-# Palette mirrors toptop's default `gruvbox` theme (src/theme.rs THEMES[0]) so
-# the hero graphic shows the colors users actually see on first launch.
-BG, BORDER = "#282828", "#fe8019"    # dark bg, accent-orange border
-TEXT, DIM = "#ebdbb2", "#928374"      # body text, dimmed labels
-ACCENT, AQUA = "#fe8019", "#83a598"   # titles/headings (orange), secondary (aqua)
-GREEN, YELLOW, RED = "#b8bb26", "#fabd2f", "#fb4934"  # load-gradient stops
-TRACK = "#3c3836"                     # meter track (selection bg)
+
+# The palette is read straight out of src/theme.rs rather than copied here, so
+# the hero graphic cannot drift away from the colors a first launch actually
+# shows — which is exactly what had happened before.
+THEME = "cyberpunk"
+
+
+def _palette(name):
+    src = os.path.join(os.path.dirname(__file__), os.pardir, "src", "theme.rs")
+    with open(src, encoding="utf-8") as fh:
+        text_src = fh.read()
+    block = re.search(
+        r'Theme \{\s*name: "%s",(.*?)gradient: &(\w+),' % name, text_src, re.S
+    )
+    if not block:
+        raise SystemExit(f"theme {name!r} not found in src/theme.rs")
+    fields = {
+        k: "#%02x%02x%02x" % (int(r), int(g), int(b))
+        for k, r, g, b in re.findall(
+            r"(\w+): (?:Some\()?rgb\((\d+), (\d+), (\d+)\)", block.group(1)
+        )
+    }
+    stops = re.search(
+        r"static %s: \[Rgb; \d+\] = \[(.*?)\];" % block.group(2), text_src, re.S
+    )
+    fields["gradient"] = [
+        "#%02x%02x%02x" % (int(r), int(g), int(b))
+        for r, g, b in re.findall(r"rgb\((\d+), (\d+), (\d+)\)", stops.group(1))
+    ]
+    return fields
+
+
+_P = _palette(THEME)
+BG, BORDER = _P["bg"], _P["accent"]
+TEXT, DIM = _P["fg"], _P["dim"]
+ACCENT, AQUA = _P["accent"], _P["accent2"]
+# The gradient's low, middle and high stops: calm → warning → saturated.
+GREEN, YELLOW, RED = _P["gradient"][0], _P["gradient"][1], _P["gradient"][-1]
+TRACK = _P["selection"]
 
 BAR_X, BAR_W, BAR_H = 188, 372, 16
 VAL_X = BAR_X + BAR_W + 14

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             tick_ms: 1500,
-            theme_idx: 0,
+            theme_idx: theme::default_index(),
             tree: false,
             per_core: true,
             layout: LayoutPreset::Full,
@@ -258,6 +258,8 @@ mod tests {
         let c = Config::default();
         assert!(c.tick_ms >= 100);
         assert!(c.theme_idx < theme::themes().len());
+        // A fresh install starts on the theme the project's own artwork uses.
+        assert_eq!(theme::themes()[c.theme_idx].name, "cyberpunk");
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -37,6 +37,11 @@ pub struct Theme {
     /// Panel background (used sparingly; mostly transparent).
     pub bg: Option<Rgb>,
     /// Dimmed text (labels, units, inactive items).
+    ///
+    /// "Dim" is a visual weight, not permission to be unreadable: this colour
+    /// carries units, key hints, the alert timeline's ages and the diagnosis
+    /// evidence. Every built-in keeps it at WCAG AA (4.5:1) against its own
+    /// background — see `dim_text_stays_legible`.
     pub dim: Rgb,
     /// Accent used for titles and the logo.
     pub accent: Rgb,
@@ -183,7 +188,7 @@ pub static BUILTINS: &[Theme] = &[
         name: "dracula",
         fg: rgb(248, 248, 242),
         bg: None,
-        dim: rgb(98, 114, 164),
+        dim: rgb(107, 124, 179),
         accent: rgb(189, 147, 249),
         accent2: rgb(139, 233, 253),
         border: rgb(68, 71, 90),
@@ -201,7 +206,7 @@ pub static BUILTINS: &[Theme] = &[
         name: "tokyonight",
         fg: rgb(192, 202, 245),
         bg: None,
-        dim: rgb(86, 95, 137),
+        dim: rgb(111, 122, 176),
         accent: rgb(122, 162, 247),
         accent2: rgb(125, 207, 255),
         border: rgb(41, 46, 66),
@@ -219,7 +224,7 @@ pub static BUILTINS: &[Theme] = &[
         name: "matrix",
         fg: rgb(0, 200, 0),
         bg: Some(rgb(0, 0, 0)),
-        dim: rgb(0, 90, 0),
+        dim: rgb(0, 139, 0),
         accent: rgb(57, 255, 20),
         accent2: rgb(120, 255, 120),
         border: rgb(0, 70, 0),
@@ -237,7 +242,7 @@ pub static BUILTINS: &[Theme] = &[
         name: "cyberpunk",
         fg: rgb(220, 235, 255),
         bg: Some(rgb(13, 6, 26)), // deep near-black violet
-        dim: rgb(110, 92, 160),
+        dim: rgb(130, 109, 189),
         accent: rgb(255, 46, 151), // neon magenta
         accent2: rgb(0, 240, 255), // electric cyan
         border: rgb(58, 42, 93),
@@ -256,7 +261,7 @@ pub static BUILTINS: &[Theme] = &[
         name: "paper",
         fg: rgb(40, 42, 54),
         bg: None, // keep the terminal's light background
-        dim: rgb(125, 128, 140),
+        dim: rgb(114, 116, 127),
         accent: rgb(156, 39, 143), // deep magenta
         accent2: rgb(2, 105, 160), // deep teal-blue
         border: rgb(175, 178, 190),
@@ -278,6 +283,18 @@ pub static BUILTINS: &[Theme] = &[
 /// disk. Populated once by [`init_user_themes`]; falls back to the built-ins
 /// when nothing was loaded (tests, `--export`, library use).
 static REGISTRY: OnceLock<Vec<Theme>> = OnceLock::new();
+
+/// Index of the theme a fresh install starts on.
+///
+/// Resolved against [`BUILTINS`] rather than [`themes`] on purpose: the
+/// registry initializes lazily, and touching it here would lock it to the
+/// built-ins before `init_user_themes` had a chance to run.
+pub fn default_index() -> usize {
+    BUILTINS
+        .iter()
+        .position(|t| t.name == "cyberpunk")
+        .unwrap_or(0)
+}
 
 /// All themes available at runtime, in cycle order.
 pub fn themes() -> &'static [Theme] {
@@ -503,6 +520,95 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("name already taken")));
         // A built-in must not be replaced by a same-named user file.
         assert_eq!(index_by_name("gruvbox"), Some(0));
+    }
+
+    /// Relative luminance, per WCAG 2.x.
+    fn luminance(c: Rgb) -> f64 {
+        let channel = |v: u8| {
+            let v = v as f64 / 255.0;
+            if v <= 0.03928 {
+                v / 12.92
+            } else {
+                ((v + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.2126 * channel(c.0) + 0.7152 * channel(c.1) + 0.0722 * channel(c.2)
+    }
+
+    /// WCAG contrast ratio between two colors, 1.0 (identical) to 21.0.
+    fn contrast(a: Rgb, b: Rgb) -> f64 {
+        let (la, lb) = (luminance(a), luminance(b));
+        let (hi, lo) = if la > lb { (la, lb) } else { (lb, la) };
+        (hi + 0.05) / (lo + 0.05)
+    }
+
+    /// The background a theme is read against: its own when it sets one,
+    /// otherwise the terminal's — assumed near-black for dark themes and
+    /// near-white for the light one.
+    fn assumed_bg(t: &Theme) -> Rgb {
+        t.bg.unwrap_or(if t.name == "paper" {
+            Rgb(255, 255, 255)
+        } else {
+            Rgb(16, 16, 16)
+        })
+    }
+
+    #[test]
+    fn body_text_is_high_contrast() {
+        for t in BUILTINS {
+            let r = contrast(t.fg, assumed_bg(t));
+            assert!(
+                r >= 7.0,
+                "{}: body text at {r:.1}:1 — below WCAG AAA",
+                t.name
+            );
+        }
+    }
+
+    #[test]
+    fn dim_text_stays_legible() {
+        // "Dim" is a visual weight, not permission to be unreadable: this
+        // colour carries units, key hints, the alert timeline's relative ages
+        // and the diagnosis evidence line.
+        for t in BUILTINS {
+            let r = contrast(t.dim, assumed_bg(t));
+            assert!(
+                r >= 4.5,
+                "{}: dim text at {r:.1}:1 — below WCAG AA for body text",
+                t.name
+            );
+        }
+    }
+
+    #[test]
+    fn accents_are_legible_as_text() {
+        // Accents title panels and mark selections — large-ish text and UI
+        // elements, so AA's 3:1 is the right bar rather than 4.5.
+        for t in BUILTINS {
+            let bg = assumed_bg(t);
+            for (label, c) in [("accent", t.accent), ("accent2", t.accent2)] {
+                let r = contrast(c, bg);
+                assert!(r >= 3.0, "{}: {label} at {r:.1}:1 — below WCAG AA", t.name);
+            }
+        }
+    }
+
+    #[test]
+    fn gradients_stay_visible_across_their_range() {
+        // A gradient that dips into the background at any point makes a meter
+        // look broken at exactly the load where you are watching it.
+        for t in BUILTINS {
+            let bg = assumed_bg(t);
+            for step in 0..=20 {
+                let v = step as f32 / 20.0;
+                let r = contrast(t.grad_rgb(v), bg);
+                assert!(
+                    r >= 2.0,
+                    "{}: gradient at {v:.2} is {r:.1}:1 against the background",
+                    t.name
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Two things about the look — one measurable, one a product decision you can veto.

### Dim text was unreadable in several themes
`dim` isn't decoration: it carries units, key hints, the alert timeline's relative ages, and the diagnosis evidence line. It sat well under the WCAG AA bar of 4.5:1 against each theme's own background:

| theme | before | after |
|---|---|---|
| `matrix` | **2.5:1** | 4.7:1 |
| `tokyonight` | **3.1:1** | 4.6:1 |
| `cyberpunk` | **3.5:1** | 4.6:1 |
| `dracula` | 4.0:1 | 4.7:1 |
| `paper` | 3.9:1 | 4.6:1 |

Each colour was moved along **its own hue ray** rather than washed toward grey, so the character survives — matrix stays pure green (`rgb(0,139,0)`), not a desaturated sage.

Four tests now enforce the floor instead of trusting it: body text at AAA, dim at AA, accents at AA-for-UI, and **the whole gradient range** staying visible against the background — a gradient that dips into the background makes a meter look broken at exactly the load you're watching it at.

### `cyberpunk` is now the default
The banner is drawn in neon magenta (`#ff2e97`), the hero animation was gruvbox, and a first launch showed gruvbox — so **the look that brings people to the repo was not the look they got**. Now all three agree.

Existing installs are unaffected: the theme is persisted in the config, so only a fresh install changes.

The hero animation now reads its palette **out of `src/theme.rs`** rather than carrying a copy — the same anti-rot principle as the dashboard test in #82, and for the same reason: it had already drifted.

> If you'd rather keep gruvbox as the default, say so and I'll revert that half — the contrast fixes stand on their own either way.

### Verification
`cargo test` — 201 green. `cargo clippy --all-targets` and `cargo fmt --check` clean. `assets/ai-demo.svg` regenerated and verified to contain only cyberpunk-palette colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cyberpunk is now the default theme.
  - The banner and hero animation now use the Cyberpunk appearance.
- **Accessibility**
  - Improved dim-text readability across built-in themes.
  - Added automated contrast checks to help meet WCAG AA guidelines.
- **Documentation**
  - Updated theme guidance, demo-generation notes, and the test-count badge.
- **Improvements**
  - The AI demo palette now stays synchronized with the selected Cyberpunk theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->