### PR TITLE
--demo: plot the simulated GPU, and show it accurately in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--demo`'s compute-vs-bandwidth trend plotted the host's GPU**, not the
+  simulated one: the history is sampled during the refresh, before the demo
+  overlay replaces the GPU. On a machine whose card reports nothing — every
+  machine the demo exists for — the trend was blank. The overlay now *replaces*
+  that tick's sample instead of adding one; appending would interleave the two
+  series and draw a comb.
+
 ### Changed
 
 - **The shipped Grafana dashboard covers the new signals** — panels for the

--- a/README.md
+++ b/README.md
@@ -31,27 +31,39 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 
 ```text
 ╭ AI · local-LLM GPU view · Esc/a to close ──────────────────────────────────╮
-│⚠ ALERTS                                                                    │
-│  [warn] gpu0 VRAM 92% — risk of spilling to RAM                            │
+│◆ MEMORY-BANDWIDTH BOUND   bandwidth 92% · compute 24%                      │
+│  → Token generation is limited by memory bandwidth, not compute — a faster │
+│  GPU core would not help. Quantize further, or batch more requests so each │
+│  weight read serves more tokens.                                           │
 │                                                                            │
-│gpu0  NVIDIA GeForce RTX 4090   290/450W  72°C                              │
-│  compute   █████████▎░░░░░░░░░░░░░░░░░░░░  31%                             │
-│  mem b/w   ███████████████████████▍░░░░░░  78%                             │
-│  vram      ███████████████████████████▌░░ 22.0 GiB / 24.0 GiB              │
-│             ⚠ near VRAM limit — models may spill to RAM (5–20× slower)     │
+│gpu0  NVIDIA GeForce RTX 4090   344/450W  74°C                              │
+│  compute   ███████▎░░░░░░░░░░░░░░░░░░░░░░  24%                             │
+│  mem b/w   ███████████████████████████▋░░  92%                             │
+│  vram      █████████████████████▊░░░░░░░░ 17.4 GiB / 24.0 GiB              │
+│  trend     compute ▲  /  ▼ bandwidth                                       │
+│            ⢀⣀⣶⣤⣴⣾⣷⣦⣤⣶⣿⣶⣤⣴⣾⣷⣦⣤⣶⣿⣶⣤                                          │
+│            ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿                                          │
+│            ⠙⠿⠿⠋⠻⠿⠟⠙⠿⠿⠋⠻⠿⠟⠙⠿⠿⠋⠻⠿                                          │
 │                                                                            │
 │Inference servers (auto-discovered)                                         │
-│  vLLM :8000  meta-llama/Llama-3-8B                                         │
-│    83.4 tok/s (0.29 tok/s/W)  prefill 1240/s  kv 64%  req 2/5  ttft 180ms  │
+│  vLLM:8000  meta-llama/Llama-3-8B                                          │
+│    73.7 tok/s (0.21 tok/s/W)  prefill 1200/s  kv 96%  ⟲ preempt 1.8/s      │
+│    phase  prefill 94% · decode 6%  — prefill-dominated (94% of tokens)     │
+│    ttft   p50 248ms  p95 662ms  p99 1038ms                                 │
+│    tpot   p50 13ms  p95 23ms  p99 33ms                                     │
 │                                                                            │
 │GPU processes (by VRAM)                                                     │
 │      PID       VRAM   CPU%  PROCESS                                        │
+│    27494   13.9 GiB   16.4  python -m vllm.entrypoints.openai.api_server   │
 ╰────────────────────────────────────────────────────────────────────────────╯
 ```
 </details>
 
-> Local LLMs are **memory‑bandwidth bound** once the model is resident, so a GPU at "31% util" can
-> still be your bottleneck. toptop shows **compute vs. bandwidth** side by side, warns **before**
+> Local LLMs are **memory‑bandwidth bound** once the model is resident, so a GPU at "24% util" can
+> still be your bottleneck. toptop doesn't just show you that — it **names the bottleneck** and
+> says what to change. Underneath, it shows **compute vs. bandwidth** side by side and over time,
+> surfaces **KV‑cache preemption** (requests thrown away and recomputed — no other terminal tool
+> shows this), reports the **TTFT/TPOT SLO triad** at p50/p95/p99, warns **before**
 > VRAM spills to system RAM (a 5–20× slowdown), reads the driver's throttle reasons, and
 > **auto‑discovers your inference servers** (vLLM · llama.cpp · Ollama · TGI · TensorRT‑LLM · LM Studio) to scrape live
 > **tokens/sec**, KV‑cache pressure and queue depth — then exports it as JSON **or Prometheus**

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-197%20green-success)
+![Tests](https://img.shields.io/badge/tests-199%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 

--- a/examples/preview.rs
+++ b/examples/preview.rs
@@ -28,6 +28,14 @@ fn main() {
     app.on_tick();
     app.on_tick();
     match overlay.as_str() {
+        // `--demo` is the first thing most visitors run; render what they see.
+        "demo" => {
+            app.demo = true;
+            app.show_ai = true;
+            for _ in 0..40 {
+                app.on_tick();
+            }
+        }
         "conn" => {
             app.show_conn = true;
             app.connections = app.collector.connections();

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -55,6 +55,12 @@ pub fn apply(c: &mut Collector, t: u64) {
         })
         .collect();
 
+    // `refresh` already sampled the *real* GPU into the history — which on a
+    // demo machine reports nothing. Replace that sample rather than adding
+    // one, or the trend would interleave an idle host card with the synthetic
+    // 4090 and draw a comb.
+    c.update_gpu_history_with(true);
+
     c.servers = vec![ServerStats {
         runtime: "vLLM",
         pid: by_cpu.first().map(|p| p.0).unwrap_or(1),
@@ -93,6 +99,29 @@ pub fn apply(c: &mut Collector, t: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_gpu_trend_reflects_the_demo_not_the_host() {
+        let mut c = Collector::new(64);
+        for t in 1..=10 {
+            // Mimic App::on_tick: the real sample first, then the overlay.
+            c.update_gpu_history_with(false);
+            apply(&mut c, t);
+        }
+        let h = &c.gpu_history[0];
+        let compute = h.compute.tail(10);
+        assert_eq!(compute.len(), 10);
+        // Appending instead of replacing would interleave the host's idle card
+        // with the synthetic 4090 and draw a comb, which is what this guards.
+        assert!(
+            compute.iter().all(|v| *v > 0.0),
+            "the trend picked up the host GPU: {compute:?}"
+        );
+        assert!(
+            h.bandwidth.tail(10).iter().all(|v| *v > 50.0),
+            "the demo is bandwidth-heavy by design"
+        );
+    }
 
     #[test]
     fn wave_stays_in_bounds() {

--- a/src/history.rs
+++ b/src/history.rs
@@ -32,6 +32,18 @@ impl History {
         self.data.push_back(value);
     }
 
+    /// Overwrite the newest sample, or append if the history is empty.
+    ///
+    /// For overlays that supersede a sample already taken this tick — the demo
+    /// mode replaces the real GPU's reading with its synthetic one. Appending
+    /// instead would interleave the two series and draw a comb.
+    pub fn replace_last(&mut self, value: f64) {
+        match self.data.back_mut() {
+            Some(last) => *last = value,
+            None => self.push(value),
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.data.len()
     }
@@ -77,6 +89,16 @@ mod tests {
         assert_eq!(h.tail(3), vec![2.0, 3.0, 4.0]);
         assert_eq!(h.last(), 4.0);
         assert_eq!(h.max(), 4.0);
+    }
+
+    #[test]
+    fn replace_last_overwrites_rather_than_appending() {
+        let mut h = History::new(4);
+        h.replace_last(1.0); // empty: behaves as a push
+        assert_eq!(h.tail(4), vec![1.0]);
+        h.push(2.0);
+        h.replace_last(9.0);
+        assert_eq!(h.tail(4), vec![1.0, 9.0], "must not grow the series");
     }
 
     #[test]

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -360,7 +360,7 @@ impl Collector {
         // Limits change when a container is resized, and the throttling
         // counters move every tick — both are a handful of small reads.
         self.cgroup = cgroup::current();
-        self.update_gpu_history();
+        self.update_gpu_history_with(false);
         self.servers = self.infer_monitor.snapshot();
         self.update_server_history();
         // Battery level moves on the order of minutes; poll it at most this
@@ -381,21 +381,32 @@ impl Collector {
     /// Keep one history per GPU, resizing when GPUs appear or disappear.
     /// A GPU that stops reporting utilization pushes 0 rather than nothing, so
     /// the time axis stays honest — a gap would silently compress the graph.
-    fn update_gpu_history(&mut self) {
+    /// Push this tick's per-GPU samples. `replace` overwrites the newest
+    /// sample instead of appending — for the demo overlay, which supersedes a
+    /// reading `refresh` already took this tick.
+    pub(crate) fn update_gpu_history_with(&mut self, replace: bool) {
         if self.gpu_history.len() != self.gpus.len() {
             self.gpu_history = (0..self.gpus.len())
                 .map(|_| GpuHistory::new(self.history_len))
                 .collect();
         }
         for (g, h) in self.gpus.iter().zip(self.gpu_history.iter_mut()) {
-            h.compute
-                .push(if g.has_util { g.util_pct as f64 } else { 0.0 });
-            h.bandwidth.push(if g.has_mem_util {
+            let compute = if g.has_util { g.util_pct as f64 } else { 0.0 };
+            let bandwidth = if g.has_mem_util {
                 g.mem_util as f64
             } else {
                 0.0
-            });
-            h.vram.push(g.mem_pct() as f64);
+            };
+            let vram = g.mem_pct() as f64;
+            if replace {
+                h.compute.replace_last(compute);
+                h.bandwidth.replace_last(bandwidth);
+                h.vram.replace_last(vram);
+            } else {
+                h.compute.push(compute);
+                h.bandwidth.push(bandwidth);
+                h.vram.push(vram);
+            }
         }
     }
 
@@ -1033,9 +1044,9 @@ mod tests {
     fn gpu_history_tracks_compute_bandwidth_and_vram() {
         let mut c = Collector::new(8);
         c.gpus = vec![fake_gpu(90.0, 30.0, 50, 100)];
-        c.update_gpu_history();
+        c.update_gpu_history_with(false);
         c.gpus = vec![fake_gpu(20.0, 95.0, 90, 100)];
-        c.update_gpu_history();
+        c.update_gpu_history_with(false);
 
         assert_eq!(c.gpu_history.len(), 1);
         let h = &c.gpu_history[0];
@@ -1050,15 +1061,15 @@ mod tests {
     fn gpu_history_resizes_when_gpus_come_and_go() {
         let mut c = Collector::new(8);
         c.gpus = vec![fake_gpu(50.0, 50.0, 1, 2), fake_gpu(50.0, 50.0, 1, 2)];
-        c.update_gpu_history();
+        c.update_gpu_history_with(false);
         assert_eq!(c.gpu_history.len(), 2);
         // A GPU disappearing (driver reload, container restart) resizes rather
         // than indexing past the end.
         c.gpus.pop();
-        c.update_gpu_history();
+        c.update_gpu_history_with(false);
         assert_eq!(c.gpu_history.len(), 1);
         c.gpus.clear();
-        c.update_gpu_history();
+        c.update_gpu_history_with(false);
         assert!(c.gpu_history.is_empty());
     }
 
@@ -1069,9 +1080,9 @@ mod tests {
         g.has_util = false;
         g.has_mem_util = false;
         c.gpus = vec![g];
-        c.update_gpu_history();
+        c.update_gpu_history_with(false);
         let before = c.gpu_history[0].compute.len();
-        c.update_gpu_history();
+        c.update_gpu_history_with(false);
         // Pushing 0 rather than nothing keeps the time axis honest — a gap
         // would silently compress the graph.
         assert_eq!(c.gpu_history[0].compute.len(), before + 1);


### PR DESCRIPTION
`toptop --demo` is the first thing most visitors run — the whole point is seeing the AI view on a machine with no GPU. Its compute-vs-bandwidth trend was plotting the **host's** card.

The history is sampled inside `Collector::refresh`, which runs *before* `demo::apply` swaps in the synthetic 4090. So on exactly the machines the demo exists for — ones whose GPU reports nothing — the trend was blank:

```
  trend     compute ▲  /  ▼ bandwidth
                                          ← four empty rows
```

Now:

```
  trend     compute ▲  /  ▼ bandwidth
            ⣶⣤⣴⣾⣷⣦⣤⣶⣿⣶⣤⣴⣾⣷⣦⣤⣶⣿⣶⣤
            ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
            ⠙⠿⠿⠋⠻⠿⠟⠙⠿⠿⠋⠻⠿⠟⠙⠿⠿⠋⠻⠿
```

The overlay **replaces** that tick's sample rather than adding one, via a new `History::replace_last`. Appending was the first thing I tried, and it draws a comb — the host's zeros interleaved with the demo's values, every other dot-column empty. The test asserts the whole window is nonzero, which is exactly what catches that.

Also adds a `demo` mode to `examples/preview`, which is how I found this: the demo's rendered output previously had no way to be eyeballed outside a real terminal.

### Verification
`cargo test` — 199 green, including a new test that mimics `on_tick`'s refresh-then-overlay order and asserts the trend carries the demo's values. `cargo clippy --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a demo overlay with simulated GPU activity and AI visualization.
  * Demo mode now replaces GPU history with simulated samples for clearer trend graphs.

* **Bug Fixes**
  * Prevented real and simulated GPU samples from mixing or producing blank graphs.

* **Documentation**
  * Updated demo output and explanations with bottleneck diagnosis, memory bandwidth, inference metrics, preemption, and SLO details.
  * Updated the test-status badge.

* **Tests**
  * Added coverage for repeated demo updates and history replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->