### PR TITLE
CI: use a prebuilt cargo-audit instead of building it every run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,14 +121,15 @@ jobs:
         run: cargo build --all-targets
 
   audit:
-    # The dependency tree is tiny, so this costs seconds and catches an
-    # advisory against ratatui/crossterm/sysinfo the day it lands.
+    # Catches an advisory against ratatui/crossterm/sysinfo the day it lands.
+    # The audit itself takes seconds against a dependency tree this small —
+    # `cargo install` was the expensive part, so a prebuilt binary is used.
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+      - name: Install cargo-audit (prebuilt)
+        uses: taiki-e/install-action@cargo-audit
       - name: Audit
         run: cargo audit


### PR DESCRIPTION
The audit job took **~3 minutes on every push**, of which the audit itself is a couple of seconds — the rest was `cargo install cargo-audit --locked` compiling from source and then discarding it.

It was consistently the last check to finish and the only thing standing between a green PR and a merge, several times over during today's work.

`taiki-e/install-action` fetches the release binary instead.

No behaviour change: the same `cargo audit` runs against the same dependency tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the dependency audit workflow by using a prebuilt installation method.
  * Reduced setup time and resource usage during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->