### PR TITLE
Make installing it a one-liner on every platform we claim to support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Hot-path regression guard
         run: cargo bench
 
+      - name: Lint the install script
+        # It is piped into `sh` from the README, so it had better be valid
+        # POSIX sh and free of the mistakes shellcheck knows about.
+        run: |
+          sh -n install.sh
+          shellcheck install.sh
+
   windows:
     # Windows support is best-effort: the process table, CPU/memory/network
     # rates and the NVIDIA GPU panel work, while the /proc-based bits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release
 
-# Build a release binary tarball and a .deb, then attach them to the GitHub
-# Release. Runs when a v* tag is pushed, or on manual dispatch with a tag name
-# (in which case the release step creates the tag at the dispatched commit —
-# useful where the git remote blocks direct tag pushes).
+# Build release binaries for every platform toptop claims to support, plus a
+# .deb, and attach them to the GitHub Release. Runs when a v* tag is pushed, or
+# on manual dispatch with a tag name (in which case the release step creates the
+# tag at the dispatched commit — useful where the git remote blocks direct tag
+# pushes).
+#
+# Every target builds on its own native runner: no cross-compilation, no
+# toolchain juggling, and each binary is exercised by `--version` on the
+# machine it was built for before it is published.
 on:
   push:
     tags: ["v*"]
@@ -16,51 +21,151 @@ on:
       tag:
         description: "Release tag (e.g. v1.0.0)"
         required: true
+      dry_run:
+        description: "Build and smoke-test every platform, but publish nothing"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
-  release:
-    name: build & publish
+  tag:
+    name: resolve tag
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - id: tag
+        env:
+          RAW: ${{ inputs.tag || github.ref_name }}
+        run: |
+          TAG="${RAW#release/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: ${{ matrix.name }}
+    needs: tag
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One platform failing to build must not silently ship a release missing
+      # that platform's binary.
+      fail-fast: true
+      matrix:
+        include:
+          - name: x86_64-linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: aarch64-linux
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: aarch64-macos
+            os: macos-latest
+            target: aarch64-apple-darwin
+          - name: x86_64-macos
+            os: macos-13
+            target: x86_64-apple-darwin
+          - name: x86_64-windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
-      - name: Build release binary
-        run: cargo build --release --locked
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
 
-      - name: Resolve release tag
-        id: tag
-        env:
-          RAW: ${{ inputs.tag || github.ref_name }}
-        run: echo "tag=${RAW#release/}" >> "$GITHUB_OUTPUT"
-
-      - name: Package tarball
-        env:
-          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+      - name: Smoke-test the binary we are about to ship
+        shell: bash
         run: |
-          VERSION="${RELEASE_TAG#v}"
-          PKG="toptop-${VERSION}-x86_64-linux"
+          BIN="target/${{ matrix.target }}/release/toptop"
+          [ "${{ runner.os }}" = "Windows" ] && BIN="${BIN}.exe"
+          "$BIN" --version
+          # --snapshot is the non-interactive path: it exercises the real
+          # collectors without needing a TTY, so a binary that cannot sample
+          # this machine fails here rather than in someone's terminal.
+          "$BIN" --snapshot > /dev/null
+
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        env:
+          VERSION: ${{ needs.tag.outputs.version }}
+        run: |
+          PKG="toptop-${VERSION}-${{ matrix.name }}"
           mkdir -p "dist/${PKG}"
-          cp target/release/toptop "dist/${PKG}/"
+          cp "target/${{ matrix.target }}/release/toptop" "dist/${PKG}/"
           cp README.md LICENSE man/toptop.1 "dist/${PKG}/"
           cp -r completions "dist/${PKG}/"
           tar -C dist -czf "dist/${PKG}.tar.gz" "${PKG}"
 
-      - name: Build .deb
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          VERSION: ${{ needs.tag.outputs.version }}
         run: |
-          cargo install cargo-deb --locked
-          cargo deb --no-build --output dist/
+          PKG="toptop-${VERSION}-${{ matrix.name }}"
+          mkdir -p "dist/${PKG}"
+          cp "target/${{ matrix.target }}/release/toptop.exe" "dist/${PKG}/"
+          cp README.md LICENSE "dist/${PKG}/"
+          cd dist && 7z a "${PKG}.zip" "${PKG}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+          if-no-files-found: error
+
+  deb:
+    # Its own job: `cargo deb` reads the asset paths in Cargo.toml, which point
+    # at target/release/ — a --target build puts the binary somewhere else, so
+    # this builds natively rather than teaching two places about the triple.
+    name: debian package
+    needs: tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deb (prebuilt)
+        uses: taiki-e/install-action@cargo-deb
+      - name: Build
+        run: cargo build --release --locked
+      - name: Package
+        run: cargo deb --no-build --output dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deb
+          path: dist/*.deb
+          if-no-files-found: error
+
+  publish:
+    name: publish release
+    needs: [tag, build, deb]
+    # A dry run proves every platform still builds without creating a release,
+    # so the pipeline can be exercised before it is trusted with a tag.
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List what is being published
+        run: ls -lh dist/
 
       - name: Publish to the GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          files: |
-            dist/*.tar.gz
-            dist/*.deb
+          tag_name: ${{ needs.tag.outputs.tag }}
+          files: dist/*
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Prebuilt binaries for every supported platform.** The release workflow built
+  only x86_64 Linux, so macOS and Windows users — both of whom the README
+  invites — had no path but cloning the repo and compiling. It is now a matrix
+  over x86_64/aarch64 Linux, Apple Silicon and Intel macOS, and x86_64 Windows,
+  each built on its own native runner and smoke-tested (`--version` and a real
+  `--snapshot`) before it is published. A `dry_run` input exercises the whole
+  pipeline without creating a release. (#8, partial)
+- **`install.sh`** — `curl -fsSL …/install.sh | sh` detects the platform,
+  fetches the right asset, **verifies the binary runs before putting it on your
+  PATH**, and installs to a writable directory already on PATH (never silently
+  sudo). POSIX sh, checked by shellcheck in CI, with actionable messages for
+  unsupported platforms and missing builds.
+
+### Changed
+
+- **The README leads with how to get it.** Install was 40% of the way down a
+  736-line document; there is now a one-line install and `toptop --demo`
+  directly under the hero, and the install section itself is binary-first with
+  a per-platform table instead of source-build-first.
+
 ### Fixed
 
 - **`--demo`'s compute-vs-bandwidth trend plotted the host's GPU**, not the

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 
 </div>
 
+
+---
+
+### Get it in one line
+
+```bash
+# Linux / macOS — downloads the right binary for your platform
+curl -fsSL https://raw.githubusercontent.com/ur-grue/toptop/main/install.sh | sh
+```
+
+<details>
+<summary>Other ways: Homebrew · .deb · Windows · from source</summary>
+
+See [Install](#-install) for every platform, or grab a binary straight from the
+[latest release](https://github.com/ur-grue/toptop/releases/latest).
+
+</details>
+
+Then, on any machine — no GPU required:
+
+```bash
+toptop --demo
+```
+
 ---
 
 **The local‑inference view (press `a`) — the numbers `nvidia-smi` doesn't show you:**
@@ -292,34 +316,68 @@ and keep retrying. No agent, no daemon, no open ports — just SSH and the singl
 
 ## 🚀 Install
 
-**From source** (requires a Rust toolchain, 1.88+):
+**One line** (Linux · macOS, x86_64 and arm64):
 
 ```bash
-git clone https://github.com/ur-grue/toptop && cd toptop
-cargo build --release
-./target/release/toptop          # or: cargo install --path .
+curl -fsSL https://raw.githubusercontent.com/ur-grue/toptop/main/install.sh | sh
 ```
 
-**Debian / Ubuntu** (`.deb` from the [v1.0.0 release](https://github.com/ur-grue/toptop/releases/latest)):
+Picks the right build for your platform, checks the binary actually runs before
+putting it on your PATH, and installs to `~/.local/bin` (override with
+`TOPTOP_BIN_DIR=...`, pin a version with `TOPTOP_VERSION=v1.2.3`). Read it
+first if you'd rather — it's [one short POSIX script](install.sh).
+
+<details>
+<summary><b>Prefer to do it by hand?</b> Every platform, one command each.</summary>
+
+**Binary** — pick your platform from the [latest
+release](https://github.com/ur-grue/toptop/releases/latest):
+
+| Platform | Asset |
+|---|---|
+| Linux x86_64 | `toptop-<version>-x86_64-linux.tar.gz` |
+| Linux arm64 | `toptop-<version>-aarch64-linux.tar.gz` |
+| macOS Apple Silicon | `toptop-<version>-aarch64-macos.tar.gz` |
+| macOS Intel | `toptop-<version>-x86_64-macos.tar.gz` |
+| Windows x86_64 | `toptop-<version>-x86_64-windows.zip` |
 
 ```bash
-wget https://github.com/ur-grue/toptop/releases/download/v1.0.1/toptop_1.0.1-1_amd64.deb
-sudo apt install ./toptop_1.0.1-1_amd64.deb   # installs binary, man page, completions
+curl -L https://github.com/ur-grue/toptop/releases/latest/download/toptop-1.0.1-x86_64-linux.tar.gz | tar xz
+sudo install -m755 toptop-1.0.1-x86_64-linux/toptop /usr/local/bin/
 ```
 
-**Binary tarball** (x86_64 Linux):
+**Windows** — download the `.zip` from the [latest
+release](https://github.com/ur-grue/toptop/releases/latest), extract it, and run
+`toptop.exe` from a terminal (Windows Terminal recommended — it does truecolor,
+which the themes rely on).
+
+**Debian / Ubuntu**:
 
 ```bash
-curl -L https://github.com/ur-grue/toptop/releases/download/v1.0.1/toptop-1.0.1-x86_64-linux.tar.gz | tar xz
-./toptop-1.0.1-x86_64-linux/toptop
+curl -LO https://github.com/ur-grue/toptop/releases/latest/download/toptop_1.0.1-1_amd64.deb
+sudo apt install ./toptop_1.0.1-1_amd64.deb   # binary, man page, completions
 ```
 
-**Homebrew** (this repo is its own tap — the [formula](Formula/toptop.rb) is pinned to v1.0.1):
+**Homebrew** — this repo is its own tap:
 
 ```bash
 brew tap ur-grue/toptop https://github.com/ur-grue/toptop
-brew trust ur-grue/toptop            # one-time: Homebrew requires approving third-party taps
-brew install toptop                  # or: brew install --HEAD toptop for the tip of main
+brew install toptop        # or: brew install --HEAD toptop for the tip of main
+```
+
+**From source** (Rust 1.88+):
+
+```bash
+cargo install --git https://github.com/ur-grue/toptop
+```
+
+</details>
+
+Then, on any machine:
+
+```bash
+toptop           # the full system monitor
+toptop --demo    # the AI view with a simulated GPU — no GPU needed
 ```
 
 ### Platform support

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# toptop installer — fetches the release binary for this platform.
+#
+#   curl -fsSL https://raw.githubusercontent.com/ur-grue/toptop/main/install.sh | sh
+#
+# Options (as environment variables):
+#   TOPTOP_VERSION=v1.2.3   install a specific release instead of the latest
+#   TOPTOP_BIN_DIR=~/.local/bin   where to put the binary
+#
+# POSIX sh, no bashisms: this has to run under dash on a minimal container as
+# readily as under zsh on a Mac.
+set -eu
+
+REPO="ur-grue/toptop"
+BIN_DIR="${TOPTOP_BIN_DIR:-}"
+
+die() {
+    printf 'toptop install: %s\n' "$1" >&2
+    exit 1
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "this needs '$1' on PATH"
+}
+
+# ── Which build do we want? ─────────────────────────────────────────────────
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+    Linux) os_name="linux" ;;
+    Darwin) os_name="macos" ;;
+    MINGW* | MSYS* | CYGWIN*)
+        die "on Windows, download the .zip from https://github.com/$REPO/releases/latest"
+        ;;
+    *) die "unsupported OS '$os' — build from source: https://github.com/$REPO#-install" ;;
+esac
+case "$arch" in
+    x86_64 | amd64) arch_name="x86_64" ;;
+    arm64 | aarch64) arch_name="aarch64" ;;
+    *) die "unsupported architecture '$arch' — build from source: https://github.com/$REPO#-install" ;;
+esac
+platform="${arch_name}-${os_name}"
+
+need uname
+need tar
+if command -v curl >/dev/null 2>&1; then
+    fetch() { curl -fsSL "$1"; }
+    fetch_to() { curl -fsSL -o "$2" "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+    fetch() { wget -qO- "$1"; }
+    fetch_to() { wget -qO "$2" "$1"; }
+else
+    die "this needs curl or wget on PATH"
+fi
+
+# ── Which version? ──────────────────────────────────────────────────────────
+version="${TOPTOP_VERSION:-}"
+if [ -z "$version" ]; then
+    # Resolve the latest tag without needing jq: the redirect target of
+    # /releases/latest ends in the tag.
+    version="$(fetch "https://api.github.com/repos/$REPO/releases/latest" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n 1)"
+    [ -n "$version" ] || die "could not determine the latest release — set TOPTOP_VERSION=vX.Y.Z"
+fi
+plain="${version#v}"
+
+asset="toptop-${plain}-${platform}.tar.gz"
+url="https://github.com/$REPO/releases/download/${version}/${asset}"
+
+# ── Download, verify, install ───────────────────────────────────────────────
+tmp="$(mktemp -d)"
+# shellcheck disable=SC2064  # $tmp must expand now, not at trap time.
+trap "rm -rf '$tmp'" EXIT INT TERM
+
+printf 'toptop install: fetching %s (%s)\n' "$version" "$platform" >&2
+fetch_to "$url" "$tmp/pkg.tar.gz" || die "no build for ${platform} in ${version}
+  Available builds: https://github.com/$REPO/releases/${version}
+  Or build from source: https://github.com/$REPO#-install"
+
+tar -xzf "$tmp/pkg.tar.gz" -C "$tmp" || die "the download is not a valid archive"
+bin="$(find "$tmp" -type f -name toptop -perm -u+x | head -n 1)"
+[ -n "$bin" ] || die "no toptop binary inside ${asset}"
+
+# Prove it runs here before putting it on the PATH: a wrong-architecture or
+# too-old-glibc binary should fail now, with an explanation, not later.
+chmod +x "$bin"
+"$bin" --version >/dev/null 2>&1 || die "the downloaded binary does not run on this machine
+  Your platform may need a source build: https://github.com/$REPO#-install"
+
+# ── Where does it go? ───────────────────────────────────────────────────────
+if [ -z "$BIN_DIR" ]; then
+    # Prefer a user-writable directory already on PATH; never sudo silently.
+    for candidate in "$HOME/.local/bin" "$HOME/bin" /usr/local/bin; do
+        case ":$PATH:" in
+            *":$candidate:"*)
+                if [ -d "$candidate" ] && [ -w "$candidate" ]; then
+                    BIN_DIR="$candidate"
+                    break
+                fi
+                ;;
+        esac
+    done
+fi
+[ -n "$BIN_DIR" ] || BIN_DIR="$HOME/.local/bin"
+mkdir -p "$BIN_DIR" || die "cannot create $BIN_DIR — set TOPTOP_BIN_DIR to somewhere writable"
+[ -w "$BIN_DIR" ] || die "$BIN_DIR is not writable — set TOPTOP_BIN_DIR to somewhere else"
+
+install -m 755 "$bin" "$BIN_DIR/toptop" 2>/dev/null \
+    || { cp "$bin" "$BIN_DIR/toptop" && chmod 755 "$BIN_DIR/toptop"; } \
+    || die "could not install into $BIN_DIR"
+
+printf 'toptop install: installed %s to %s/toptop\n' "$version" "$BIN_DIR" >&2
+case ":$PATH:" in
+    *":$BIN_DIR:"*)
+        printf '\nRun it:\n  toptop --demo\n' >&2
+        ;;
+    *)
+        # shellcheck disable=SC2016  # $PATH is literal here: it is a line the
+        # reader pastes into their shell, not something to expand now.
+        printf '\n%s is not on your PATH. Add it:\n  export PATH="%s:$PATH"\n\nThen run:\n  toptop --demo\n' \
+            "$BIN_DIR" "$BIN_DIR" >&2
+        ;;
+esac


### PR DESCRIPTION
> ⚠️ **This makes the README promise something that needs a release to be cut.** Today's v1.0.1 has Linux assets only, so the one-liner will report `no build for aarch64-macos in v1.0.1` until a tag is pushed with this workflow. See the bottom.

You asked whether install and usage are low-friction. Three things said no:

### 1. We shipped binaries for one platform out of three
The README invites macOS and Windows users, CI proves both build, and the platform badge lists all three — but the release workflow built **only x86_64 Linux**.

- **macOS:** `brew tap` + `brew trust` + a **source build** needing Rust 1.88.
- **Windows:** no documented path at all beyond "clone it".
- **Linux arm64:** nothing.

Now a five-target matrix — x86_64/aarch64 Linux, Apple Silicon and Intel macOS, x86_64 Windows — each on its **own native runner**, so no cross-compilation. Every binary is smoke-tested on the machine it was built for before publication: `--version`, plus `--snapshot`, which exercises the real collectors without needing a TTY. `fail-fast: true`, so a broken platform can't silently ship a release missing it.

The `.deb` moved to its own job: `cargo deb` reads Cargo.toml's asset paths, which point at `target/release/`, and a `--target` build puts the binary elsewhere.

A **`dry_run` input** builds and smoke-tests every platform while skipping publish — the pipeline can be exercised before it's trusted with a tag.

### 2. There was no one-liner
```bash
curl -fsSL https://raw.githubusercontent.com/ur-grue/toptop/main/install.sh | sh
```

Detects platform, resolves the latest tag, downloads, extracts, and — **before putting anything on your PATH — runs the binary** to prove it works here. A wrong-architecture download fails with an explanation instead of an exec-format error later. Installs into a writable directory already on PATH; never silently sudos. POSIX sh (dash-compatible), shellcheck-clean, and CI now lints it, since it's piped into `sh` from the README.

**Tested end to end** against a local release fixture: download → extract → verify → install → run, with correct permissions and a PATH hint. The wrong-architecture path was tested by pointing it at the real v1.0.1 **Linux** tarball from **macOS** — which is precisely the failure the check exists for:

```
toptop install: fetching v1.0.1 (x86_64-linux)
toptop install: the downloaded binary does not run on this machine
  Your platform may need a source build: …
```

### 3. Install was 40% down the page
Line 293 of 736, below 250 lines of feature prose. A one-line install and `toptop --demo` now sit directly under the hero, and the install section is binary-first with a per-platform asset table rather than leading with a source build.

A consistency check confirmed every asset name the README promises is one the workflow actually builds.

---

### What you need to do
The install paths resolve **after** a release is cut with this workflow. Two options:

1. **Dry run first** (safe, creates nothing):
   `gh workflow run release.yml -f tag=v1.0.2 -f dry_run=true`
   That proves all five platforms build and smoke-test.
2. **Then cut it:** push a `v1.0.2` tag, or `gh workflow run release.yml -f tag=v1.0.2`.

I didn't do either — cutting a release is yours to make.

`cargo install toptop` still needs crates.io (#8), which needs your account.

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a cross-platform installer for Linux, macOS, and Windows.
  - Installer automatically detects the platform, downloads the appropriate release, validates the binary, and supports custom versions and destinations.
  - Added prebuilt release binaries and platform-specific installation options, including Debian/Ubuntu and Homebrew.
- **Documentation**
  - Simplified the quick-start experience with a one-line installation command.
  - Expanded installation guidance and added demo-focused usage instructions.
- **Bug Fixes**
  - Added clearer error handling for unsupported platforms, invalid downloads, and unwritable installation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->