### PR TITLE
Point the empty AI view at --demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The empty AI view points at `--demo`.** Opening it on a machine with no GPU
+  explained that there was no GPU and stopped there; nobody would guess the
+  whole view can be demonstrated without one. It now says so — except while the
+  demo is already running.
+
 ### Fixed
 
 - **`--demo`'s compute-vs-bandwidth trend plotted the host's GPU**, not the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with a gorgeous full system monitor underneath. Rust · one tiny binary · zero 
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-informational)
 ![Dependencies](https://img.shields.io/badge/runtime%20deps-0-success)
-![Tests](https://img.shields.io/badge/tests-203%20green-success)
+![Tests](https://img.shields.io/badge/tests-204%20green-success)
 
 [AI view](#-for-ai-engineers) · [Fleet](#-multi-host-fleet-view) · [Prometheus](#-export--observability) · [Install](#-install) · [Features](#-features) · [Themes](#-themes)
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1370,6 +1370,20 @@ fn render_ai(f: &mut Frame, area: Rect, app: &App) {
             "AI workloads and inference servers still show below.",
             dim(theme),
         )));
+        // Someone who opens this view and finds it empty has no reason to
+        // guess that the whole thing can be demonstrated without a GPU.
+        if !app.demo {
+            lines.push(Line::from(vec![
+                Span::styled("Run ", dim(theme)),
+                Span::styled(
+                    "toptop --demo",
+                    Style::default()
+                        .fg(theme.accent.color())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" to see this view with a simulated GPU.", dim(theme)),
+            ]));
+        }
         lines.push(Line::from(Span::raw("")));
     }
 

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -774,3 +774,26 @@ fn the_ai_view_leads_with_a_diagnosis() {
         "the advice was clipped before its end:\n{joined}"
     );
 }
+
+/// Opening the AI view on a machine with no GPU must point somewhere, not just
+/// report emptiness — `--demo` is the whole answer and nobody would guess it.
+#[test]
+fn the_empty_ai_view_points_at_the_demo() {
+    let mut app = App::new(&Config::default());
+    app.collector.gpus.clear();
+    app.show_ai = true;
+    let screen = render_text(&mut app, 110, 34).join("\n");
+    assert!(
+        screen.contains("toptop --demo"),
+        "no way out of an empty AI view:\n{screen}"
+    );
+
+    // …but not while the demo is already running, which would be absurd.
+    app.demo = true;
+    app.collector.gpus.clear();
+    let screen = render_text(&mut app, 110, 34).join("\n");
+    assert!(
+        !screen.contains("toptop --demo"),
+        "suggested the demo during the demo"
+    );
+}


### PR DESCRIPTION
Pressing `a` on a machine with no GPU said this:

```
Apple Silicon GPU metrics aren't wired up yet (tracked in ur-grue/toptop#4).
AI workloads and inference servers still show below.
```

Accurate, and a dead end — at exactly the moment someone is deciding whether this tool is for them. The answer (`toptop --demo`) is documented in a README they may not have read and is impossible to guess from inside the app.

```
Apple Silicon GPU metrics aren't wired up yet (tracked in ur-grue/toptop#4).
AI workloads and inference servers still show below.
Run toptop --demo to see this view with a simulated GPU.
```

Suppressed while the demo is already running, which the test also checks.

`cargo test` — 204 green. clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance to launch demo mode when the AI view has no GPU available.
  * Automatically hides the demo instruction when demo mode is already active.

* **Documentation**
  * Updated installation instructions with platform-specific options, Windows guidance, and post-install usage examples.
  * Added a prominent demo command and updated the changelog.

* **Tests**
  * Added regression coverage for displaying and suppressing the demo instruction appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->