### PR TITLE
Cross-compile the Intel macOS build instead of queueing forever

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,15 @@ jobs:
             os: macos-latest
             target: aarch64-apple-darwin
           - name: x86_64-macos
-            os: macos-13
+            # Cross-compiled from the arm64 runner: GitHub has retired the
+            # Intel `macos-13` runners for public repos, and a job that queues
+            # forever would block every release. Apple's toolchain targets
+            # x86_64 from arm64 natively, so this is a first-class build — it
+            # just cannot be *executed* here, which is why the smoke test below
+            # skips this one target rather than lying about having run it.
+            os: macos-latest
             target: x86_64-apple-darwin
+            cross: true
           - name: x86_64-windows
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -82,6 +89,9 @@ jobs:
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Smoke-test the binary we are about to ship
+        # Skipped only for the cross-compiled target, which this runner cannot
+        # execute. Every natively-built binary is run before it is published.
+        if: ${{ !matrix.cross }}
         shell: bash
         run: |
           BIN="target/${{ matrix.target }}/release/toptop"
@@ -91,6 +101,19 @@ jobs:
           # collectors without needing a TTY, so a binary that cannot sample
           # this machine fails here rather than in someone's terminal.
           "$BIN" --snapshot > /dev/null
+
+      - name: Verify the cross-compiled binary is what we think it is
+        if: ${{ matrix.cross }}
+        shell: bash
+        run: |
+          BIN="target/${{ matrix.target }}/release/toptop"
+          file "$BIN"
+          # It cannot be run here, so at least assert the architecture — a
+          # silently-arm64 "Intel" build would be worse than no Intel build.
+          file "$BIN" | grep -q "x86_64" || {
+            echo "expected an x86_64 binary, got: $(file "$BIN")" >&2
+            exit 1
+          }
 
       - name: Package (unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
The dry run of #86's release matrix surfaced this immediately: every job finished except `x86_64-macos`, which **sat queued indefinitely**. GitHub has retired the Intel `macos-13` runners for public repos.

```
resolve tag:      success
debian package:   success
aarch64-linux:    success
x86_64-linux:     success
aarch64-macos:    success
x86_64-windows:   success
x86_64-macos:     queued  ← forever
```

The matrix is `fail-fast`, so that job would have blocked **every release**. A release that never publishes is worse than one missing a platform.

Apple's toolchain targets x86_64 from arm64 natively, so the Intel build now happens on `macos-latest` as a first-class cross-compile.

What it *cannot* do there is run. Rather than pretend, the execution smoke test is skipped for that one target — and replaced with an architecture assertion:

```bash
file "$BIN" | grep -q "x86_64" || exit 1
```

An "Intel" download that turns out to be arm64 would be worse than no Intel download at all. Every natively-built binary is still executed (`--version` and a real `--snapshot`) before publication.

This is exactly what the `dry_run` input was for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eVHJ4NKGPC8VpA61JyX5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS release builds to use the current hosted build environment.
  * Improved validation to ensure x86_64 macOS packages contain the correct architecture.
  * Kept native smoke tests running while appropriately excluding cross-compiled artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->